### PR TITLE
*: update project meta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,10 @@ jobs:
       # allow(clippy::all) fails in the syscrate, so we can't use --all here:
       script: |
         if rustup component add clippy-preview ; then
-            cargo clippy -p jemalloc-sys -- -D clippy::all
-            cargo clippy -p jemallocator -- -D clippy::all
-            cargo clippy -p jemallocator-global -- -D clippy::all
-            cargo clippy -p jemalloc-ctl -- -D clippy::all
+            cargo clippy -p tikv-jemalloc-sys -- -D clippy::all
+            cargo clippy -p tikv-jemallocator -- -D clippy::all
+            cargo clippy -p tikv-jemallocator-global -- -D clippy::all
+            cargo clippy -p tikv-jemalloc-ctl -- -D clippy::all
         fi
     - name: "Shellcheck"
       install: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 0.4.0 - 2020-07-21
+
+- Forked from jemallocator master
+- Upgraded jemalloc to 5.2.1 (#1)
+- Fixed wrong version in generated C header (#1)
+- Upgraded project to 2018 edition (#2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,32 @@
 [package]
-name = "jemallocator"
+name = "tikv-jemallocator"
 # Make sure to update the version in the README as well:
-version = "0.3.2"
+version = "0.4.0"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
     "Simon Sapin <simon.sapin@exyr.org>",
-    "Steven Fackler <sfackler@gmail.com>"
+    "Steven Fackler <sfackler@gmail.com>",
+    "The TiKV Project Developers",
 ]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["allocator", "jemalloc"]
 categories = ["memory-management", "api-bindings"]
-repository = "https://github.com/gnzlbg/jemallocator"
-homepage = "https://github.com/gnzlbg/jemallocator"
-documentation = "https://docs.rs/jemallocator"
+repository = "https://github.com/tikv/jemallocator"
+homepage = "https://github.com/tikv/jemallocator"
+documentation = "https://docs.rs/tikv-jemallocator"
 description = """
 A Rust allocator backed by jemalloc
 """
-edition = "2015"
+edition = "2018"
 
 [badges]
-appveyor = { repository = "gnzlbg/jemallocator" }
-travis-ci = { repository = "gnzlbg/jemallocator" }
-codecov = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-issue-resolution = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-open-issues = { repository = "gnzlbg/jemallocator" }
+appveyor = { repository = "tikv/jemallocator" }
+travis-ci = { repository = "tikv/jemallocator" }
+codecov = { repository = "tikv/jemallocator" }
+is-it-maintained-issue-resolution = { repository = "tikv/jemallocator" }
+is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [lib]
@@ -36,23 +37,23 @@ bench = false
 members = ["systest", "jemallocator-global", "jemalloc-ctl", "jemalloc-sys" ]
 
 [dependencies]
-jemalloc-sys = { path = "jemalloc-sys", version = "0.3.2", default-features = false }
+tikv-jemalloc-sys = { path = "jemalloc-sys", version = "0.4.0", default-features = false }
 libc = { version = "^0.2.8", default-features = false }
 
 [dev-dependencies]
 paste = "0.1"
-jemalloc-ctl = { path = "jemalloc-ctl", version = "0.3" }
+tikv-jemalloc-ctl = { path = "jemalloc-ctl", version = "0.4" }
 
 [features]
 default = ["background_threads_runtime_support"]
 alloc_trait = []
-profiling = ["jemalloc-sys/profiling"]
-debug = ["jemalloc-sys/debug"]
-stats = ["jemalloc-sys/stats"]
-background_threads_runtime_support = ["jemalloc-sys/background_threads_runtime_support"]
-background_threads = ["jemalloc-sys/background_threads"]
-unprefixed_malloc_on_supported_platforms = ["jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
-disable_initial_exec_tls = ["jemalloc-sys/disable_initial_exec_tls"]
+profiling = ["tikv-jemalloc-sys/profiling"]
+debug = ["tikv-jemalloc-sys/debug"]
+stats = ["tikv-jemalloc-sys/stats"]
+background_threads_runtime_support = ["tikv-jemalloc-sys/background_threads_runtime_support"]
+background_threads = ["tikv-jemalloc-sys/background_threads"]
+unprefixed_malloc_on_supported_platforms = ["tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
+disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
 
 [package.metadata.docs.rs]
 features = [ "alloc_trait" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# jemallocator
+# tikv-jemallocator
 
 [![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
+
+This project is a simplified fork of [jemallocator](https://github.com/gnzlbg/jemallocator) focus on server.
 
 > Links against `jemalloc` and provides a `Jemalloc` unit type that implements
 > the allocator APIs and can be set as the `#[global_allocator]`
@@ -9,10 +11,10 @@
 
 The `jemalloc` support ecosystem consists of the following crates:
 
-* `jemalloc-sys`: builds and links against `jemalloc` exposing raw C bindings to it.
-* `jemallocator`: provides the `Jemalloc` type which implements the
+* `tikv-jemalloc-sys`: builds and links against `jemalloc` exposing raw C bindings to it.
+* `tikv-jemallocator`: provides the `Jemalloc` type which implements the
   `GlobalAlloc` and `Alloc` traits. 
-* `jemalloc-ctl`: high-level wrapper over `jemalloc`'s control and introspection
+* `tikv-jemalloc-ctl`: high-level wrapper over `jemalloc`'s control and introspection
   APIs (the `mallctl*()` family of functions and the _MALLCTL NAMESPACE_)'
 
 ## Documentation
@@ -20,22 +22,22 @@ The `jemalloc` support ecosystem consists of the following crates:
 * [Latest release (docs.rs)][docs.rs]
 * [Master branch][master_docs]
 
-To use `jemallocator` add it as a dependency:
+To use `tikv-jemallocator` add it as a dependency:
 
 ```toml
 # Cargo.toml
 [dependencies]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = "0.3.2"
+tikv-jemallocator = "0.4.0"
 ```
 
-To set `jemallocator::Jemalloc` as the global allocator add this to your project:
+To set `tikv_jemallocator::Jemalloc` as the global allocator add this to your project:
 
 ```rust
 # main.rs
 #[cfg(not(target_env = "msvc"))]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -50,8 +52,8 @@ all allocations requested by Rust code in the same program.
 The following table describes the supported platforms: 
 
 * `build`: does the library compile for the target?
-* `run`: do `jemallocator` and `jemalloc-sys` tests pass on the target?
-* `jemalloc`: do `jemalloc`'s tests pass on the target?
+* `run`: do `tikv-jemallocator` and `tikv-jemalloc-sys` tests pass on the target?
+* `jemalloc`: do `tikv-jemalloc`'s tests pass on the target?
 * `valgrind`: do the tests pass under valgrind?
 
 Tier 1 targets are tested on all Rust channels (stable, beta, and nightly). All
@@ -60,34 +62,15 @@ other targets are only tested on Rust nightly.
 | Linux targets:                      | build     | run     | jemalloc     | valgrind     |
 |-------------------------------------|-----------|---------|--------------|--------------|
 | `aarch64-unknown-linux-gnu`         | ✓         | ✓       | ✗            | ✗            |
-| `arm-unknown-linux-gnueabi`         | ✓         | ✓       | ✗            | ✗            |
-| `armv7-unknown-linux-gnueabi`       | ✓         | ✓       | ✗            | ✗            |
-| `i586-unknown-linux-gnu`            | ✓         | ✓       | ✓            | ✗            |
-| `i686-unknown-linux-gnu` (tier 1)   | ✓         | ✓       | ✓            | ✗            |
-| `mips-unknown-linux-gnu`            | ✓         | ✓       | ✗            | ✗            |
-| `mipsel-unknown-linux-musl`         | ✓         | ✓       | ✗            | ✗            |
-| `mips64-unknown-linux-gnuabi64`     | ✓         | ✓       | ✗            | ✗            |
-| `mips64el-unknown-linux-gnuabi64`   | ✓         | ✓       | ✗            | ✗            |
-| `powerpc-unknown-linux-gnu`         | ✓         | ✓       | ✗            | ✗            |
-| `powerpc64-unknown-linux-gnu`       | ✓         | ✓       | ✗            | ✗            |
 | `powerpc64le-unknown-linux-gnu`     | ✓         | ✓       | ✗            | ✗            |
 | `x86_64-unknown-linux-gnu` (tier 1) | ✓         | ✓       | ✓            | ✓            |
 | **MacOSX targets:**                 | **build** | **run** | **jemalloc** | **valgrind** |
 | `x86_64-apple-darwin` (tier 1)      | ✓         | ✓       | ✗            | ✗            |
-| `i686-apple-darwin` (tier 1)        | ✓         | ✓       | ✗            | ✗            |
-| **Windows targets:**                | **build** | **run** | **jemalloc** | **valgrind** |
-| `x86_64-pc-windows-msvc` (tier 1)   | ✗         | ✗       | ✗            | ✗            |
-| `i686-pc-windows-msvc` (tier 1)     | ✗         | ✗       | ✗            | ✗            |
-| `x86_64-pc-windows-gnu` (tier 1)    | ✓         | ✓       | ✗            | ✗            |
-| `i686-pc-windows-gnu` (tier 1)      | ✓         | ✓       | ✗            | ✗            |
-| **Android targets:**                | **build** | **run** | **jemalloc** | **valgrind** |
-| `aarch64-linux-android`             | ✓         | ✓       | ✗            | ✗            |
-| `x86_64-linux-android`              | ✓         | ✓       | ✓            | ✗            |
 
 ## Features
 
-The `jemallocator` crate re-exports the [features of the `jemalloc-sys`
-dependency](https://github.com/gnzlbg/jemallocator/blob/master/jemalloc-sys/README.md).
+The `tikv-jemallocator` crate re-exports the [features of the `tikv-jemalloc-sys`
+dependency](https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md).
 
 ## License
 
@@ -103,15 +86,14 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `jemallocator` by you, as defined in the Apache-2.0 license,
+for inclusion in `tikv-jemallocator` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[travis]: https://travis-ci.com/gnzlbg/jemallocator
-[Travis-CI Status]: https://travis-ci.com/gnzlbg/jemallocator.svg?branch=master
-[appveyor]: https://ci.appveyor.com/project/gnzlbg/jemallocator/branch/master
-[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/gnzlbg/jemallocator?branch=master&svg=true
-[Latest Version]: https://img.shields.io/crates/v/jemallocator.svg
-[crates.io]: https://crates.io/crates/jemallocator
-[docs]: https://docs.rs/jemallocator/badge.svg
-[docs.rs]: https://docs.rs/jemallocator/
-[master_docs]: https://gnzlbg.github.io/jemallocator/jemallocator
+[travis]: https://travis-ci.com/tikv/jemallocator
+[Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/tikv/jemallocator/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/tikv/jemallocator?branch=master&svg=true
+[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
+[crates.io]: https://crates.io/crates/tikv-jemallocator
+[docs]: https://docs.rs/tikv-jemallocator/badge.svg
+[docs.rs]: https://docs.rs/tikv-jemallocator/

--- a/benches/roundtrip.rs
+++ b/benches/roundtrip.rs
@@ -3,13 +3,8 @@
 #![feature(test, allocator_api)]
 #![cfg(feature = "alloc_trait")]
 
-extern crate jemalloc_sys;
-extern crate jemallocator;
-extern crate libc;
-extern crate paste;
 extern crate test;
 
-use jemalloc_sys::MALLOCX_ALIGN;
 use jemallocator::Jemalloc;
 use libc::c_int;
 use std::{
@@ -17,6 +12,7 @@ use std::{
     ptr,
 };
 use test::Bencher;
+use tikv_jemalloc_sys::MALLOCX_ALIGN;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -4,5 +4,5 @@ set -ex
 
 export RUSTDOCFLAGS="--cfg jemallocator_docs"
 cargo doc --features alloc_trait
-cargo doc -p jemalloc-sys
-cargo doc -p jemalloc-ctl
+cargo doc -p tikv-jemalloc-sys
+cargo doc -p tikv-jemalloc-ctl

--- a/jemalloc-ctl/Cargo.toml
+++ b/jemalloc-ctl/Cargo.toml
@@ -1,36 +1,38 @@
 [package]
-name = "jemalloc-ctl"
-version = "0.3.3"
+name = "tikv-jemalloc-ctl"
+version = "0.4.0"
 authors = [
     "Steven Fackler <sfackler@gmail.com>",
-    "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"
+    "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+    "The TiKV Project Developers",
 ]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 categories = ["memory-management", "api-bindings", "development-tools" ]
 keywords = ["allocator", "jemalloc"]
-repository = "https://github.com/gnzlbg/jemallocator"
-homepage = "https://github.com/gnzlbg/jemallocator"
-documentation = "https://docs.rs/jemalloc-ctl"
+repository = "https://github.com/tikv/jemallocator"
+homepage = "https://github.com/tikv/jemallocator"
+documentation = "https://docs.rs/tikv-jemalloc-ctl"
 description = """
 A safe wrapper over jemalloc's control and introspection APIs
 """
+edition = "2018"
 
 [badges]
-appveyor = { repository = "gnzlbg/jemallocator" }
-travis-ci = { repository = "gnzlbg/jemallocator" }
-codecov = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-issue-resolution = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-open-issues = { repository = "gnzlbg/jemallocator" }
+appveyor = { repository = "tikv/jemallocator" }
+travis-ci = { repository = "tikv/jemallocator" }
+codecov = { repository = "tikv/jemallocator" }
+is-it-maintained-issue-resolution = { repository = "tikv/jemallocator" }
+is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-jemalloc-sys = { path = "../jemalloc-sys", version = "0.3.2" }
+tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.4.0" }
 libc = { version = "0.2", default-features = false }
 paste = { version = "0.1" }
 
 [dev-dependencies]
-jemallocator = { path = "..", version = "0.3.2" }
+tikv-jemallocator = { path = "..", version = "0.4.0" }
 
 [features]
 default = []

--- a/jemalloc-ctl/README.md
+++ b/jemalloc-ctl/README.md
@@ -11,20 +11,18 @@
 
 ## Platform support
 
-Supported on all platforms supported by the [`jemallocator`] crate.
+Supported on all platforms supported by the [`tikv-jemallocator`] crate.
 
 ## Example
 
 ```no_run
-extern crate jemallocator;
-extern crate jemalloc_ctl;
 
 use std::thread;
 use std::time::Duration;
-use jemalloc_ctl::{stats, epoch};
+use tikv_jemalloc_ctl::{stats, epoch};
 
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
     // Obtain a MIB for the `epoch`, `stats.allocated`, and
@@ -64,13 +62,12 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `jemalloc-ctl` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[`jemallocator`]: https://github.com/gnzlbg/jemallocator
-[travis]: https://travis-ci.org/gnzlbg/jemallocator
-[Travis-CI Status]: https://travis-ci.org/gnzlbg/jemallocator.svg?branch=master
-[appveyor]: https://ci.appveyor.com/project/gnzlbg/jemallocator/branch/master
-[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/gnzlbg/jemallocator?branch=master&svg=true
-[Latest Version]: https://img.shields.io/crates/v/jemalloc-ctl.svg
-[crates.io]: https://crates.io/crates/jemalloc-ctl
-[docs]: https://docs.rs/jemalloc-ctl/badge.svg
-[docs.rs]: https://docs.rs/jemalloc-ctl/
-[master_docs]: https://gnzlbg.github.io/jemallocator/jemalloc-ctl
+[`tikv-jemallocator`]: https://github.com/tikv/jemallocator
+[travis]: https://travis-ci.com/tikv/jemallocator
+[Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/tikv/jemallocator/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/tikv/jemallocator?branch=master&svg=true
+[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
+[crates.io]: https://crates.io/crates/tikv-jemallocator
+[docs]: https://docs.rs/tikv-jemallocator/badge.svg
+[docs.rs]: https://docs.rs/tikv-jemallocator/

--- a/jemalloc-ctl/src/arenas.rs
+++ b/jemalloc-ctl/src/arenas.rs
@@ -9,14 +9,12 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
     /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::arenas;
+    /// use tikv_jemalloc_ctl::arenas;
     /// println!("number of arenas: {}", arenas::narenas::read().unwrap());
     ///
     /// let arenas_mib = arenas::narenas::mib().unwrap();

--- a/jemalloc-ctl/src/config.rs
+++ b/jemalloc-ctl/src/config.rs
@@ -12,14 +12,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::config;
+    /// use tikv_jemalloc_ctl::config;
     /// let malloc_conf = config::malloc_conf::mib().unwrap();
     /// println!("default malloc conf: {}", malloc_conf.read().unwrap());
     /// # }

--- a/jemalloc-ctl/src/error.rs
+++ b/jemalloc-ctl/src/error.rs
@@ -4,8 +4,8 @@
     allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)
 )]
 
+use crate::{fmt, num, result};
 use libc::c_int;
-use {fmt, num, result};
 
 pub trait NonZeroT {
     type T;
@@ -19,7 +19,7 @@ impl NonZeroT for i64 {
 
 pub type NonZeroCInt = <c_int as NonZeroT>::T;
 
-/// Errors of the `jemalloc_sys::mallct`-family of functions.
+/// Errors of the `tikv_jemalloc_sys::mallct`-family of functions.
 ///
 /// The `jemalloc-sys` crate: `mallctl`, `mallctlnametomib`, and `mallctlbymib``
 /// functions return `0` on success; otherwise they return an error value.
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn size_of_result_error() {
-        use mem::size_of;
+        use crate::mem::size_of;
         assert_eq!(size_of::<Result<()>>(), size_of::<Error>());
         assert_eq!(size_of::<Error>(), size_of::<libc::c_int>());
     }

--- a/jemalloc-ctl/src/keys.rs
+++ b/jemalloc-ctl/src/keys.rs
@@ -8,15 +8,11 @@
 //! # Example
 //!
 //! ```
-//! extern crate libc;
-//! extern crate jemallocator;
-//! extern crate jemalloc_ctl;
-//!
 //! #[global_allocator]
-//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 //!
 //! fn main() {
-//!     use jemalloc_ctl::{Access, AsName, Name, Mib};
+//!     use tikv_jemalloc_ctl::{Access, AsName, Name, Mib};
 //!     use libc::{c_uint, c_char};
 //!     let name = b"arenas.nbins\0".name();
 //!     let nbins: c_uint = name.read().unwrap();
@@ -29,9 +25,9 @@
 //! }
 //! ```
 
-use error::Result;
-use std::str;
-use {fmt, ops, raw};
+use crate::error::Result;
+use crate::std::str;
+use crate::{fmt, ops, raw};
 
 /// A `Name` in the _MALLCTL NAMESPACE_.
 #[repr(transparent)]

--- a/jemalloc-ctl/src/lib.rs
+++ b/jemalloc-ctl/src/lib.rs
@@ -19,15 +19,12 @@
 //! Repeatedly printing allocation statistics:
 //!
 //! ```no_run
-//! extern crate jemallocator;
-//! extern crate jemalloc_ctl;
-//!
 //! use std::thread;
 //! use std::time::Duration;
-//! use jemalloc_ctl::{stats, epoch};
+//! use tikv_jemalloc_ctl::{stats, epoch};
 //!
 //! #[global_allocator]
-//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 //!
 //! fn main() {
 //!     loop {
@@ -45,15 +42,12 @@
 //! Doing the same with the MIB-based API:
 //!
 //! ```no_run
-//! extern crate jemallocator;
-//! extern crate jemalloc_ctl;
-//!
 //! use std::thread;
 //! use std::time::Duration;
-//! use jemalloc_ctl::{stats, epoch};
+//! use tikv_jemalloc_ctl::{stats, epoch};
 //!
 //! #[global_allocator]
-//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 //!
 //! fn main() {
 //!     let e = epoch::mib().unwrap();
@@ -74,20 +68,15 @@
 #![cfg_attr(not(feature = "use_std"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::module_name_repetitions))]
 
-extern crate jemalloc_sys;
-extern crate libc;
-extern crate paste;
-
-#[cfg(test)]
-extern crate jemallocator;
-
 #[cfg(test)]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+use crate::std::{fmt, mem, num, ops, ptr, result, slice, str};
 #[cfg(not(feature = "use_std"))]
 use core as std;
-use std::{fmt, mem, num, ops, ptr, result, slice, str};
+#[cfg(feature = "use_std")]
+use std;
 
 #[macro_use]
 mod macros;
@@ -115,14 +104,11 @@ option! {
     /// # Example
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::version;
+    /// use tikv_jemalloc_ctl::version;
     /// println!("jemalloc version {}", version::read().unwrap());
     /// let version_mib = version::mib().unwrap();
     /// println!("jemalloc version {}", version_mib.read().unwrap());
@@ -142,16 +128,13 @@ option! {
     /// arenas). Threads run periodically and handle purging asynchronously.
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// # #[cfg(not(target_os = "macos"))] {
     /// #
-    /// use jemalloc_ctl::background_thread;
+    /// use tikv_jemalloc_ctl::background_thread;
     /// let bg = background_thread::mib().unwrap();
     /// let s = bg.read().unwrap();
     /// println!("background_threads enabled: {}", s);
@@ -175,16 +158,13 @@ option! {
     /// Maximum number of background threads that will be created.
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// # #[cfg(not(target_os = "macos"))] {
     /// #
-    /// use jemalloc_ctl::max_background_threads;
+    /// use tikv_jemalloc_ctl::max_background_threads;
     /// let m = max_background_threads::mib().unwrap();
     /// println!("max_background_threads: {}", m.read().unwrap());
     /// m.write(0).unwrap();
@@ -210,15 +190,12 @@ option! {
     /// Advancing the epoch:
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// #
-    /// use jemalloc_ctl::epoch;
+    /// use tikv_jemalloc_ctl::epoch;
     /// let e = epoch::mib().unwrap();
     /// let a = e.advance().unwrap();
     /// let b = e.advance().unwrap();
@@ -232,14 +209,14 @@ option! {
 
 impl epoch {
     /// Advances the epoch returning its old value - see [`epoch`].
-    pub fn advance() -> ::error::Result<u64> {
+    pub fn advance() -> crate::error::Result<u64> {
         Self::update(1)
     }
 }
 
 impl epoch_mib {
     /// Advances the epoch returning its old value - see [`epoch`].
-    pub fn advance(self) -> ::error::Result<u64> {
+    pub fn advance(self) -> crate::error::Result<u64> {
         self.0.update(1)
     }
 }

--- a/jemalloc-ctl/src/macros.rs
+++ b/jemalloc-ctl/src/macros.rs
@@ -11,10 +11,10 @@ macro_rules! types {
             pub struct $id;
 
             impl $id {
-                const NAME: &'static ::keys::Name = {
+                const NAME: &'static crate::keys::Name = {
                     union U<'a> {
                         bytes: &'a [u8],
-                        name: &'a ::keys::Name
+                        name: &'a crate::keys::Name
                     }
 
                     unsafe { U { bytes: $byte_string }.name }
@@ -22,12 +22,12 @@ macro_rules! types {
                 /// Returns Management Information Base (MIB)
                 ///
                 /// This value can be used to access the key without doing string lookup.
-                pub fn mib() -> ::error::Result<[<$id _mib>]> {
+                pub fn mib() -> crate::error::Result<[<$id _mib>]> {
                     Ok([<$id _mib>](Self::NAME.$name_to_mib()?))
                 }
 
                 /// Key [`::keys::Name`].
-                pub fn name() -> &'static ::keys::Name {
+                pub fn name() -> &'static crate::keys::Name {
                     Self::NAME
                 }
             }
@@ -36,7 +36,7 @@ macro_rules! types {
             #[repr(transparent)]
             #[derive(Copy, Clone)]
             #[allow(non_camel_case_types)]
-            pub struct [<$id _mib>](pub ::keys::$mib);
+            pub struct [<$id _mib>](pub crate::keys::$mib);
         }
     };
 }
@@ -47,16 +47,16 @@ macro_rules! r {
         paste::item! {
             impl $id {
                 /// Reads value using string API.
-                pub fn read() -> ::error::Result<$ret_ty> {
-                    use ::keys::Access;
+                pub fn read() -> crate::error::Result<$ret_ty> {
+                    use crate::keys::Access;
                     Self::NAME.read()
                 }
             }
 
             impl [<$id _mib>] {
                 /// Reads value using MIB API.
-                pub fn read(self) -> ::error::Result<$ret_ty> {
-                    use ::keys::Access;
+                pub fn read(self) -> crate::error::Result<$ret_ty> {
+                    use crate::keys::Access;
                     self.0.read()
                 }
             }
@@ -96,16 +96,16 @@ macro_rules! w {
         paste::item! {
             impl $id {
                 /// Writes `value` using string API.
-                pub fn write(value: $ret_ty) -> ::error::Result<()> {
-                    use ::keys::Access;
+                pub fn write(value: $ret_ty) -> crate::error::Result<()> {
+                    use crate::keys::Access;
                     Self::NAME.write(value)
                 }
             }
 
             impl [<$id _mib>] {
                 /// Writes `value` using MIB API.
-                pub fn write(self, value: $ret_ty) -> ::error::Result<()> {
-                    use ::keys::Access;
+                pub fn write(self, value: $ret_ty) -> crate::error::Result<()> {
+                    use crate::keys::Access;
                     self.0.write(value)
                 }
             }
@@ -145,16 +145,16 @@ macro_rules! u {
         paste::item! {
             impl $id {
                 /// Updates key to `value` returning its old value using string API.
-                pub fn update(value: $ret_ty) -> ::error::Result<$ret_ty> {
-                    use ::keys::Access;
+                pub fn update(value: $ret_ty) -> crate::error::Result<$ret_ty> {
+                    use crate::keys::Access;
                     Self::NAME.update(value)
                 }
             }
 
             impl [<$id _mib>] {
                 /// Updates key to `value` returning its old value using MIB API.
-                pub fn update(self, value: $ret_ty) -> ::error::Result<$ret_ty> {
-                    use ::keys::Access;
+                pub fn update(self, value: $ret_ty) -> crate::error::Result<$ret_ty> {
+                    use crate::keys::Access;
                     self.0.update(value)
                 }
             }

--- a/jemalloc-ctl/src/opt.rs
+++ b/jemalloc-ctl/src/opt.rs
@@ -14,14 +14,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let abort = opt::abort::mib().unwrap();
     /// println!("abort on warning: {}", abort.read().unwrap());
     /// # }
@@ -44,14 +41,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let dss = opt::dss::read().unwrap();
     /// println!("dss priority: {}", dss);
     /// # }
@@ -72,14 +66,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let narenas = opt::narenas::read().unwrap();
     /// println!("number of arenas: {}", narenas);
     /// # }
@@ -109,14 +100,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let junk = opt::junk::read().unwrap();
     /// println!("junk filling: {}", junk);
     /// # }
@@ -140,14 +128,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let zero = opt::zero::read().unwrap();
     /// println!("zeroing: {}", zero);
     /// # }
@@ -168,14 +153,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let tcache = opt::tcache::read().unwrap();
     /// println!("thread-local caching: {}", tcache);
     /// # }
@@ -196,14 +178,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let lg_tcache_max = opt::lg_tcache_max::read().unwrap();
     /// println!("max cached allocation size: {}", 1 << lg_tcache_max);
     /// # }
@@ -225,14 +204,11 @@ option! {
     /// # Examples
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::opt;
+    /// use tikv_jemalloc_ctl::opt;
     /// let background_thread = opt::background_thread::read().unwrap();
     /// println!("background threads since initialization: {}", background_thread);
     /// # }

--- a/jemalloc-ctl/src/stats.rs
+++ b/jemalloc-ctl/src/stats.rs
@@ -18,14 +18,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let allocated = stats::allocated::mib().unwrap();
     ///
@@ -56,14 +53,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let active = stats::active::mib().unwrap();
     ///
@@ -91,14 +85,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let metadata = stats::metadata::mib().unwrap();
     ///
@@ -132,14 +123,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let resident = stats::resident::mib().unwrap();
     ///
@@ -170,14 +158,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let mapped = stats::mapped::mib().unwrap();
     ///
@@ -208,14 +193,11 @@ option! {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::{epoch, stats};
+    /// use tikv_jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let retained = stats::retained::mib().unwrap();
     ///

--- a/jemalloc-ctl/src/stats_print.rs
+++ b/jemalloc-ctl/src/stats_print.rs
@@ -1,7 +1,5 @@
 //! Bulk statistics output.
 
-extern crate std;
-
 use libc::{c_char, c_void};
 use std::any::Any;
 use std::ffi::CStr;
@@ -54,7 +52,7 @@ pub struct Options {
 struct State<W> {
     writer: W,
     error: io::Result<()>,
-    panic: Result<(), Box<Any + Send>>,
+    panic: Result<(), Box<dyn Any + Send>>,
 }
 
 extern "C" fn callback<W>(opaque: *mut c_void, buf: *const c_char)
@@ -125,7 +123,7 @@ where
         }
         opts[i] = 0;
 
-        jemalloc_sys::malloc_stats_print(
+        tikv_jemalloc_sys::malloc_stats_print(
             Some(callback::<W>),
             &mut state as *mut _ as *mut c_void,
             opts.as_ptr(),

--- a/jemalloc-ctl/src/thread.rs
+++ b/jemalloc-ctl/src/thread.rs
@@ -1,7 +1,7 @@
 //! Thread specific operations.
 
-use error::Result;
-use raw::{read, read_mib};
+use crate::error::Result;
+use crate::raw::{read, read_mib};
 
 option! {
     allocatedp[ str: b"thread.allocatedp\0", non_str: 2 ] => *mut u64 |
@@ -22,14 +22,11 @@ option! {
     /// # Example
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::thread;
+    /// use tikv_jemalloc_ctl::thread;
     /// let allocated = thread::allocatedp::mib().unwrap();
     /// let allocated = allocated.read().unwrap();
     ///
@@ -75,14 +72,11 @@ option! {
     /// # Example
     ///
     /// ```
-    /// # extern crate jemallocator;
-    /// # extern crate jemalloc_ctl;
-    /// #
     /// # #[global_allocator]
-    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use jemalloc_ctl::thread;
+    /// use tikv_jemalloc_ctl::thread;
     /// let deallocated = thread::deallocatedp::mib().unwrap();
     /// let deallocated = deallocated.read().unwrap();
     ///

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,29 +1,30 @@
 [package]
-name = "jemalloc-sys"
-version = "0.3.2"
+name = "tikv-jemalloc-sys"
+version = "0.4.0+5.2.1"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+    "The TiKV Project Developers",
 ]
 build = "build.rs"
 links = "jemalloc"
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/gnzlbg/jemallocator"
-homepage = "https://github.com/gnzlbg/jemallocator"
-documentation = "https://docs.rs/jemallocator-sys"
+repository = "https://github.com/tikv/jemallocator"
+homepage = "https://github.com/tikv/jemallocator"
+documentation = "https://docs.rs/tikv-jemallocator-sys"
 keywords = ["allocator", "jemalloc"]
 description = """
 Rust FFI bindings to jemalloc
 """
-edition = "2015"
+edition = "2018"
 
 [badges]
-appveyor = { repository = "gnzlbg/jemallocator" }
-travis-ci = { repository = "gnzlbg/jemallocator" }
-codecov = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-issue-resolution = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-open-issues = { repository = "gnzlbg/jemallocator" }
+appveyor = { repository = "tikv/jemallocator" }
+travis-ci = { repository = "tikv/jemallocator" }
+codecov = { repository = "tikv/jemallocator" }
+is-it-maintained-issue-resolution = { repository = "tikv/jemallocator" }
+is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [lib]

--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -3,7 +3,7 @@
 [![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
 > Note: the Rust allocator API is implemented for `jemalloc` in the
-> [`jemallocator`](https://crates.io/crates/jemallocator) crate.
+> [`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) crate.
 
 ## Documentation
 
@@ -20,12 +20,12 @@
 [jemalloc_docs]: http://jemalloc.net/jemalloc.3.html
 [jemalloc_wiki]: https://github.com/jemalloc/jemalloc/wiki
 
-**Current jemalloc version**: 5.1.
+**Current jemalloc version**: 5.2.1.
 
 ## Platform support
 
 See the platform support of the
-[`jemallocator`](https://crates.io/crates/jemallocator) crate.
+[`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) crate.
 
 ## Features
 
@@ -160,15 +160,14 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `jemalloc-sys` by you, as defined in the Apache-2.0 license,
+for inclusion in `tikv-jemalloc-sys` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[travis]: https://travis-ci.org/gnzlbg/jemallocator
-[Travis-CI Status]: https://travis-ci.org/gnzlbg/jemallocator.svg?branch=master
-[appveyor]: https://ci.appveyor.com/project/gnzlbg/jemallocator/branch/master
-[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/gnzlbg/jemallocator?branch=master&svg=true
-[Latest Version]: https://img.shields.io/crates/v/jemalloc-sys.svg
-[crates.io]: https://crates.io/crates/jemalloc-ctl
-[docs]: https://docs.rs/jemalloc-sys/badge.svg
-[docs.rs]: https://docs.rs/jemalloc-sys/
-[master_docs]: https://gnzlbg.github.io/jemallocator/jemalloc-sys
+[travis]: https://travis-ci.com/tikv/jemallocator
+[Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/tikv/jemallocator/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/tikv/jemallocator?branch=master&svg=true
+[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
+[crates.io]: https://crates.io/crates/tikv-jemallocator
+[docs]: https://docs.rs/tikv-jemallocator/badge.svg
+[docs.rs]: https://docs.rs/tikv-jemallocator/

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate cc;
-extern crate fs_extra;
-
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -47,8 +47,6 @@
 )]
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 
-extern crate libc;
-
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 type c_bool = c_int;
 

--- a/jemalloc-sys/tests/malloc_conf_empty.rs
+++ b/jemalloc-sys/tests/malloc_conf_empty.rs
@@ -1,8 +1,6 @@
-extern crate jemalloc_sys;
-
 #[test]
 fn malloc_conf_empty() {
     unsafe {
-        assert!(jemalloc_sys::malloc_conf.is_none());
+        assert!(tikv_jemalloc_sys::malloc_conf.is_none());
     }
 }

--- a/jemalloc-sys/tests/malloc_conf_set.rs
+++ b/jemalloc-sys/tests/malloc_conf_set.rs
@@ -1,6 +1,3 @@
-extern crate jemalloc_sys;
-extern crate libc;
-
 union U {
     x: &'static u8,
     y: &'static libc::c_char,
@@ -19,11 +16,11 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 #[test]
 fn malloc_conf_set() {
     unsafe {
-        assert_eq!(jemalloc_sys::malloc_conf, malloc_conf);
+        assert_eq!(tikv_jemalloc_sys::malloc_conf, malloc_conf);
 
         let mut ptr: *const libc::c_char = std::ptr::null();
         let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
-        let r = jemalloc_sys::mallctl(
+        let r = tikv_jemalloc_sys::mallctl(
             &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
             &mut ptr as *mut *const _ as *mut libc::c_void,
             &mut ptr_len as *mut _,

--- a/jemalloc-sys/tests/unprefixed_malloc.rs
+++ b/jemalloc-sys/tests/unprefixed_malloc.rs
@@ -1,14 +1,11 @@
-extern crate jemalloc_sys;
-extern crate libc;
-
 #[cfg(prefixed)]
 #[test]
 fn malloc_is_prefixed() {
-    assert_ne!(jemalloc_sys::malloc as usize, libc::malloc as usize)
+    assert_ne!(tikv_jemalloc_sys::malloc as usize, libc::malloc as usize)
 }
 
 #[cfg(not(prefixed))]
 #[test]
 fn malloc_is_overridden() {
-    assert_eq!(jemalloc_sys::malloc as usize, libc::malloc as usize)
+    assert_eq!(tikv_jemalloc_sys::malloc as usize, libc::malloc as usize)
 }

--- a/jemallocator-global/Cargo.toml
+++ b/jemallocator-global/Cargo.toml
@@ -1,42 +1,45 @@
 [package]
-name = "jemallocator-global"
+name = "tikv-jemallocator-global"
 # Make sure to update the version in the readme as well:
-version = "0.3.2"
-authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
-edition = "2015"
+version = "0.4.0"
+authors = [
+    "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+    "The TiKV Project Developers",
+]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["allocator", "jemalloc"]
 categories = ["memory-management", "api-bindings"]
-repository = "https://github.com/gnzlbg/jemallocator"
-homepage = "https://github.com/gnzlbg/jemallocator"
-documentation = "https://docs.rs/jemallocator-global"
+repository = "https://github.com/tikv/jemallocator"
+homepage = "https://github.com/tikv/jemallocator"
+documentation = "https://docs.rs/tikv-jemallocator-global"
 description = """
 Sets `jemalloc` as the `#[global_allocator]`
 """
 
  [badges]
-appveyor = { repository = "gnzlbg/jemallocator" }
-travis-ci = { repository = "gnzlbg/jemallocator" }
-codecov = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-issue-resolution = { repository = "gnzlbg/jemallocator" }
-is-it-maintained-open-issues = { repository = "gnzlbg/jemallocator" }
+appveyor = { repository = "tikv/jemallocator" }
+travis-ci = { repository = "tikv/jemallocator" }
+codecov = { repository = "tikv/jemallocator" }
+is-it-maintained-issue-resolution = { repository = "tikv/jemallocator" }
+is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-jemallocator = { version = "0.3.2", path = "..", optional = true }
+tikv-jemallocator = { version = "0.4.0", path = "..", optional = true }
 cfg-if = "0.1"
 
 [features]
 default = []
 # Unconditionally sets jemalloc as the global allocator:
-force_global_jemalloc = [ "jemallocator" ]
+force_global_jemalloc = [ "tikv-jemallocator" ]
 
 # To enable `jemalloc` as the `#[global_allocator]` by default
 # for a particular target, white-list the target explicitly here:
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-jemallocator = { version = "0.3.2", path = "..", optional = false }
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
+tikv-jemallocator = { version = "0.4.0", path = "..", optional = false }
 
 # FIXME: https://github.com/gnzlbg/jemallocator/issues/91
 # [target.'cfg(target_os = "windows")'.dependencies]

--- a/jemallocator-global/README.md
+++ b/jemallocator-global/README.md
@@ -11,7 +11,7 @@ Add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-jemallocator-global = "0.3.0"
+tikv-jemallocator-global = "0.4.0"
 ```
 
 and `jemalloc` will be used as the `#[global_allocator]` on targets that support
@@ -22,7 +22,7 @@ it.
 * `force_global_jemalloc` (disabled by default): unconditionally sets `jemalloc`
   as the `#[global_allocator]`.
 
-[`jemallocator`]: https://github.com/gnzlbg/jemallocator/
+[`tikv-jemallocator`]: https://github.com/tikv/jemallocator/
 
 ## Platform support 
 
@@ -46,15 +46,14 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `jemallocator-global` by you, as defined in the Apache-2.0 license,
+for inclusion in `tikv-jemallocator-global` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[travis]: https://travis-ci.org/gnzlbg/jemallocator
-[Travis-CI Status]: https://travis-ci.org/gnzlbg/jemallocator.svg?branch=master
-[appveyor]: https://ci.appveyor.com/project/gnzlbg/jemallocator/branch/master
-[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/gnzlbg/jemallocator?branch=master&svg=true
-[Latest Version]: https://img.shields.io/crates/v/jemallocator-global.svg
-[crates.io]: https://crates.io/crates/jemallocator-global
-[docs]: https://docs.rs/jemallocator-global/badge.svg
-[docs.rs]: https://docs.rs/jemallocator-global/
-
+[travis]: https://travis-ci.com/tikv/jemallocator
+[Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/tikv/jemallocator/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/tikv/jemallocator?branch=master&svg=true
+[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
+[crates.io]: https://crates.io/crates/tikv-jemallocator
+[docs]: https://docs.rs/tikv-jemallocator/badge.svg
+[docs.rs]: https://docs.rs/tikv-jemallocator/

--- a/jemallocator-global/src/lib.rs
+++ b/jemallocator-global/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! jemallocator-global = "0.3.0"
+//! jemallocator-global = "0.4.0"
 //! ```
 //!
 //! and `jemalloc` will be used as the `#[global_allocator]` on targets that
@@ -21,18 +21,14 @@ cfg_if! {
     if #[cfg(any(
         feature = "force_global_jemalloc",
         target_os = "linux",
-        target_os = "android",
         target_os = "macos",
-        target_os = "ios",
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd"
     ))] {
-        extern crate jemallocator;
-
         /// Sets `jemalloc` as the `#[global_allocator]`.
         #[global_allocator]
-        pub static JEMALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+        pub static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,6 @@
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![no_std]
 
-extern crate jemalloc_sys;
-extern crate libc;
-
 #[cfg(feature = "alloc_trait")]
 use core::alloc::{Alloc, AllocErr, CannotReallocInPlace, Excess};
 use core::alloc::{GlobalAlloc, Layout};
@@ -287,5 +284,5 @@ pub unsafe fn usable_size<T>(ptr: *const T) -> usize {
 
 /// Raw bindings to jemalloc
 mod ffi {
-    pub use jemalloc_sys::*;
+    pub use tikv_jemalloc_sys::*;
 }

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -3,9 +3,10 @@ name = "systest"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
-jemalloc-sys = { path = "../jemalloc-sys" }
+tikv-jemalloc-sys = { path = "../jemalloc-sys" }
 libc = "0.2"
 
 [build-dependencies]

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -1,5 +1,3 @@
-extern crate ctest;
-
 use std::env;
 use std::path::PathBuf;
 

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -1,14 +1,11 @@
 #![allow(bad_style, improper_ctypes, dead_code, unused_imports)]
 
-extern crate jemalloc_sys;
-extern crate libc;
-
 use std::alloc::System;
 
 #[global_allocator]
 static A: System = System;
 
-use jemalloc_sys::*;
 use libc::{c_char, c_int, c_void};
+use tikv_jemalloc_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));

--- a/tests/background_thread_defaults.rs
+++ b/tests/background_thread_defaults.rs
@@ -1,17 +1,13 @@
 //! Test background threads run-time default settings.
 
-extern crate jemalloc_ctl;
-extern crate jemallocator;
-extern crate libc;
-
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
 
 // Returns true if background threads are enabled.
 fn background_threads() -> bool {
-    jemalloc_ctl::opt::background_thread::read().unwrap()
+    tikv_jemalloc_ctl::opt::background_thread::read().unwrap()
 }
 
 #[test]

--- a/tests/background_thread_enabled.rs
+++ b/tests/background_thread_enabled.rs
@@ -4,11 +4,7 @@
 #![cfg(not(feature = "unprefixed_malloc_on_supported_platforms"))]
 #![cfg(not(target_env = "musl"))]
 
-extern crate jemalloc_ctl;
-extern crate jemallocator;
-extern crate libc;
-
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
@@ -32,5 +28,8 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 #[test]
 fn background_threads_enabled() {
     // Background threads are unconditionally enabled at run-time by default.
-    assert_eq!(jemalloc_ctl::opt::background_thread::read().unwrap(), true);
+    assert_eq!(
+        tikv_jemalloc_ctl::opt::background_thread::read().unwrap(),
+        true
+    );
 }

--- a/tests/ffi.rs
+++ b/tests/ffi.rs
@@ -1,12 +1,10 @@
-extern crate jemalloc_sys as ffi;
-extern crate jemallocator;
-extern crate libc;
+extern crate tikv_jemalloc_sys as ffi;
 
 use std::mem;
 use std::ptr;
 
-use jemallocator::Jemalloc;
 use libc::{c_char, c_void};
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/grow_in_place.rs
+++ b/tests/grow_in_place.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
 
-extern crate jemallocator;
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/malloctl.rs
+++ b/tests/malloctl.rs
@@ -1,10 +1,6 @@
-extern crate jemalloc_ctl;
-extern crate jemallocator;
-extern crate libc;
-
-use jemalloc_ctl::{Access, AsName};
-use jemallocator::Jemalloc;
 use std::alloc::{GlobalAlloc, Layout};
+use tikv_jemalloc_ctl::{Access, AsName};
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/shrink_in_place.rs
+++ b/tests/shrink_in_place.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
 
-extern crate jemallocator;
-
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,7 +1,5 @@
-extern crate jemallocator;
-
-use jemallocator::Jemalloc;
 use std::alloc::{GlobalAlloc, Layout};
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/smoke_ffi.rs
+++ b/tests/smoke_ffi.rs
@@ -1,16 +1,13 @@
-extern crate jemalloc_sys;
-extern crate jemallocator;
-
 // Work around https://github.com/gnzlbg/jemallocator/issues/19
 #[global_allocator]
-static A: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static A: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[test]
 fn smoke() {
     unsafe {
-        let ptr = jemalloc_sys::malloc(4);
+        let ptr = tikv_jemalloc_sys::malloc(4);
         *(ptr as *mut u32) = 0xDECADE;
         assert_eq!(*(ptr as *mut u32), 0xDECADE);
-        jemalloc_sys::free(ptr);
+        tikv_jemalloc_sys::free(ptr);
     }
 }

--- a/tests/usable_size.rs
+++ b/tests/usable_size.rs
@@ -1,6 +1,4 @@
-extern crate jemallocator;
-
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
@@ -8,5 +6,5 @@ static A: Jemalloc = Jemalloc;
 #[test]
 fn smoke() {
     let a = Box::new(3_u32);
-    assert!(unsafe { jemallocator::usable_size(&*a) } >= 4);
+    assert!(unsafe { tikv_jemallocator::usable_size(&*a) } >= 4);
 }


### PR DESCRIPTION
As we are going to publish the crate to crates.io, we need a different
name and version. Since native library is upgraded, all versions are
bumpped to 0.4.0. To make it clear which version of jemalloc is used, I
attach a build tag 5.2.1.

And the project are upgraded to 2018 version.