### PR TITLE
jemalloc-sys: switch to 5.2.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "jemalloc-sys/jemalloc"]
 	path = jemalloc-sys/jemalloc
-	url = https://github.com/jemalloc/jemalloc
-	branch = master
+	url = https://github.com/tikv/jemalloc
+	branch = v5.2.x

--- a/jemalloc-ctl/src/lib.rs
+++ b/jemalloc-ctl/src/lib.rs
@@ -64,7 +64,7 @@
 //!     }
 //! }
 //! ```
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![deny(missing_docs, broken_intra_doc_links)]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::module_name_repetitions))]
 

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -45,7 +45,7 @@
     feature = "cargo-clippy",
     allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)
 )]
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![deny(missing_docs, broken_intra_doc_links)]
 
 use libc::{c_char, c_int, c_uint, c_void, size_t};
 type c_bool = c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! and is suitable both as a memory allocator and as a global allocator.
 
 #![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![deny(missing_docs, broken_intra_doc_links)]
 #![no_std]
 
 #[cfg(feature = "alloc_trait")]


### PR DESCRIPTION
We fixed a deadlock bug in jemalloc when prof feature is used. This pr switches the jemalloc to our fork to use the patch early.