### PR TITLE
fix compile for win gnu target

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ other targets are only tested on Rust nightly.
 | `x86_64-unknown-linux-gnu` (tier 1) | ✓         | ✓       | ✓            |
 | **MacOSX targets:**                 | **build** | **run** | **jemalloc** |
 | `x86_64-apple-darwin` (tier 1)      | ✓         | ✓       | ✗            |
+| **Windows targets:**                | **build** | **run** | **jemalloc** |
+| `x86_64-pc-windows-msvc` (tier 1)   | ✗         | ✗       | ✗            |
+| `i686-pc-windows-msvc` (tier 1)     | ✗         | ✗       | ✗            |
+| `x86_64-pc-windows-gnu` (tier 1)    | ✓         | ✓       | ✗            |
+| `i686-pc-windows-gnu` (tier 1)      | ✓         | ✓       | ✗            |
 
 ## Features
 

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -257,7 +257,7 @@ fn main() {
 
     cmd.arg(format!("--host={}", gnu_target(&target)));
     cmd.arg(format!("--build={}", gnu_target(&host)));
-    cmd.arg(format!("--prefix={}", out_dir.display()));
+    cmd.arg(format!("--prefix={}", out_dir.to_str().unwrap().replace("C:\\", "/c/").replace("\\", "/")));
 
     run_and_log(&mut cmd, &build_dir.join("config.log"));
 
@@ -289,6 +289,14 @@ fn main() {
         .arg("-j")
         .arg(num_jobs));
 
+    if target.contains("windows") && target.contains("gnu") {
+        run(Command::new("ar")
+            .current_dir(&build_dir)
+            .arg("rsc")
+            .arg("lib/libjemalloc.a")
+            .arg("src/*.o"));
+    }
+
     println!("cargo:root={}", out_dir.display());
 
     // Linkage directives to pull in jemalloc and its dependencies.
@@ -303,7 +311,7 @@ fn main() {
     } else {
         println!("cargo:rustc-link-lib=static=jemalloc_pic");
     }
-    println!("cargo:rustc-link-search=native={}/lib", build_dir.display());
+    println!("cargo:rustc-link-search=native={}", build_dir.join("lib").display());
     if target.contains("android") {
         println!("cargo:rustc-link-lib=gcc");
     } else if !target.contains("windows") {


### PR DESCRIPTION
### problem

Directly build on win gnu target will raise error:

```error: could not find native static library `jemalloc`, perhaps an -L flag is missing?```

### reason

1. the code below will search `libjemalloc.a` in `$build_dir/lib`:

https://github.com/tikv/jemallocator/blob/52de4257fab3e770f73d5174c12a095b49572fba/jemalloc-sys/build.rs#L306

2. however win gnu will generate `jemalloc.lib` in `$build_dir/lib`

So they are mismatching.

### fix

I update the `jemalloc-sys/build.rs` to generate `libjemalloc.a` in `$build_dir/lib`, base on the [issue](https://github.com/gnzlbg/jemallocator/issues/153).