### PR TITLE
*: revert name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:    
+      - 'master'
+      - 'tikv-main'
+  push:
+    branches:
+      - 'master'
+      - 'tikv-main'
 
 jobs:
   test:
@@ -73,9 +81,9 @@ jobs:
         submodules: true
     - run: rustup component add rustfmt clippy
     - run: cargo fmt --all -- --check
-    - run: cargo clippy -p tikv-jemalloc-sys -- -D clippy::all
-    - run: cargo clippy -p tikv-jemallocator -- -D clippy::all
-    - run: cargo clippy -p tikv-jemallocator-global -- -D clippy::all
-    - run: cargo clippy -p tikv-jemalloc-ctl -- -D clippy::all
+    - run: cargo clippy -p jemalloc-sys -- -D clippy::all
+    - run: cargo clippy -p jemallocator -- -D clippy::all
+    - run: cargo clippy -p jemallocator-global -- -D clippy::all
+    - run: cargo clippy -p jemalloc-ctl -- -D clippy::all
     - run: env RUSTDOCFLAGS="--cfg jemallocator_docs" cargo doc
     - run: shellcheck ci/*.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tikv-jemallocator"
+name = "jemallocator"
 # Make sure to update the version in the README as well:
 version = "0.4.3"
 authors = [
@@ -15,7 +15,7 @@ keywords = ["allocator", "jemalloc"]
 categories = ["memory-management", "api-bindings"]
 repository = "https://github.com/tikv/jemallocator"
 homepage = "https://github.com/tikv/jemallocator"
-documentation = "https://docs.rs/tikv-jemallocator"
+documentation = "https://docs.rs/jemallocator"
 description = """
 A Rust allocator backed by jemalloc
 """
@@ -36,23 +36,23 @@ bench = false
 members = ["systest", "jemallocator-global", "jemalloc-ctl", "jemalloc-sys" ]
 
 [dependencies]
-tikv-jemalloc-sys = { path = "jemalloc-sys", version = "0.4.0", default-features = false }
+jemalloc-sys = { path = "jemalloc-sys", version = "0.4.0", default-features = false }
 libc = { version = "^0.2.8", default-features = false }
 
 [dev-dependencies]
 paste = "1"
-tikv-jemalloc-ctl = { path = "jemalloc-ctl", version = "0.4" }
+jemalloc-ctl = { path = "jemalloc-ctl", version = "0.4" }
 
 [features]
 default = ["background_threads_runtime_support"]
 alloc_trait = []
-profiling = ["tikv-jemalloc-sys/profiling"]
-debug = ["tikv-jemalloc-sys/debug"]
-stats = ["tikv-jemalloc-sys/stats"]
-background_threads_runtime_support = ["tikv-jemalloc-sys/background_threads_runtime_support"]
-background_threads = ["tikv-jemalloc-sys/background_threads"]
-unprefixed_malloc_on_supported_platforms = ["tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
-disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
+profiling = ["jemalloc-sys/profiling"]
+debug = ["jemalloc-sys/debug"]
+stats = ["jemalloc-sys/stats"]
+background_threads_runtime_support = ["jemalloc-sys/background_threads_runtime_support"]
+background_threads = ["jemalloc-sys/background_threads"]
+unprefixed_malloc_on_supported_platforms = ["jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
+disable_initial_exec_tls = ["jemalloc-sys/disable_initial_exec_tls"]
 
 [package.metadata.docs.rs]
 features = []

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project is a simplified fork of [jemallocator](https://github.com/gnzlbg/jemallocator) focus on server.
 
+The difference between `tikv-jemallocator` and `jemallocator` is only name. The source is the same.
+
 > Links against `jemalloc` and provides a `Jemalloc` unit type that implements
 > the allocator APIs and can be set as the `#[global_allocator]`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tikv-jemallocator
+# jemallocator
 
 [![ci]][github actions] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
@@ -11,32 +11,32 @@ This project is a simplified fork of [jemallocator](https://github.com/gnzlbg/je
 
 The `jemalloc` support ecosystem consists of the following crates:
 
-* `tikv-jemalloc-sys`: builds and links against `jemalloc` exposing raw C bindings to it.
-* `tikv-jemallocator`: provides the `Jemalloc` type which implements the
+* `jemalloc-sys`: builds and links against `jemalloc` exposing raw C bindings to it.
+* `jemallocator`: provides the `Jemalloc` type which implements the
   `GlobalAlloc` and `Alloc` traits. 
-* `tikv-jemalloc-ctl`: high-level wrapper over `jemalloc`'s control and introspection
+* `jemalloc-ctl`: high-level wrapper over `jemalloc`'s control and introspection
   APIs (the `mallctl*()` family of functions and the _MALLCTL NAMESPACE_)'
 
 ## Documentation
 
 * [Latest release (docs.rs)][docs.rs]
 
-To use `tikv-jemallocator` add it as a dependency:
+To use `jemallocator` add it as a dependency:
 
 ```toml
 # Cargo.toml
 [dependencies]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.4.0"
+jemallocator = "0.4.0"
 ```
 
-To set `tikv_jemallocator::Jemalloc` as the global allocator add this to your project:
+To set `jemallocator::Jemalloc` as the global allocator add this to your project:
 
 ```rust
 # main.rs
 #[cfg(not(target_env = "msvc"))]
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -51,8 +51,8 @@ all allocations requested by Rust code in the same program.
 The following table describes the supported platforms: 
 
 * `build`: does the library compile for the target?
-* `run`: do `tikv-jemallocator` and `tikv-jemalloc-sys` tests pass on the target?
-* `jemalloc`: do `tikv-jemalloc`'s tests pass on the target?
+* `run`: do `jemallocator` and `jemalloc-sys` tests pass on the target?
+* `jemalloc`: do `jemalloc`'s tests pass on the target?
 
 Tier 1 targets are tested on all Rust channels (stable, beta, and nightly). All
 other targets are only tested on Rust nightly.
@@ -67,7 +67,7 @@ other targets are only tested on Rust nightly.
 
 ## Features
 
-The `tikv-jemallocator` crate re-exports the [features of the `tikv-jemalloc-sys`
+The `jemallocator` crate re-exports the [features of the `jemalloc-sys`
 dependency](https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md).
 
 ## License
@@ -84,12 +84,12 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `tikv-jemallocator` by you, as defined in the Apache-2.0 license,
+for inclusion in `jemallocator` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
-[crates.io]: https://crates.io/crates/tikv-jemallocator
-[docs]: https://docs.rs/tikv-jemallocator/badge.svg
-[docs.rs]: https://docs.rs/tikv-jemallocator/
+[Latest Version]: https://img.shields.io/crates/v/jemallocator.svg
+[crates.io]: https://crates.io/crates/jemallocator
+[docs]: https://docs.rs/jemallocator/badge.svg
+[docs.rs]: https://docs.rs/jemallocator/
 [ci]: https://github.com/tikv/jemallocator/actions/workflows/main.yml/badge.svg
 [github actions]: https://github.com/tikv/jemallocator/actions

--- a/benches/roundtrip.rs
+++ b/benches/roundtrip.rs
@@ -12,7 +12,7 @@ use std::{
     ptr,
 };
 use test::Bencher;
-use tikv_jemalloc_sys::MALLOCX_ALIGN;
+use jemalloc_sys::MALLOCX_ALIGN;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -4,5 +4,5 @@ set -ex
 
 export RUSTDOCFLAGS="--cfg jemallocator_docs"
 cargo doc --features alloc_trait
-cargo doc -p tikv-jemalloc-sys
-cargo doc -p tikv-jemalloc-ctl
+cargo doc -p jemalloc-sys
+cargo doc -p jemalloc-ctl

--- a/jemalloc-ctl/Cargo.toml
+++ b/jemalloc-ctl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tikv-jemalloc-ctl"
+name = "jemalloc-ctl"
 version = "0.4.2"
 authors = [
     "Steven Fackler <sfackler@gmail.com>",
@@ -12,7 +12,7 @@ categories = ["memory-management", "api-bindings", "development-tools" ]
 keywords = ["allocator", "jemalloc"]
 repository = "https://github.com/tikv/jemallocator"
 homepage = "https://github.com/tikv/jemallocator"
-documentation = "https://docs.rs/tikv-jemalloc-ctl"
+documentation = "https://docs.rs/jemalloc-ctl"
 description = """
 A safe wrapper over jemalloc's control and introspection APIs
 """
@@ -26,12 +26,12 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.4.0" }
+jemalloc-sys = { path = "../jemalloc-sys", version = "0.4.0" }
 libc = { version = "0.2", default-features = false }
 paste = "1"
 
 [dev-dependencies]
-tikv-jemallocator = { path = "..", version = "0.4.0" }
+jemallocator = { path = "..", version = "0.4.0" }
 
 [features]
 default = []

--- a/jemalloc-ctl/README.md
+++ b/jemalloc-ctl/README.md
@@ -10,7 +10,7 @@
 
 ## Platform support
 
-Supported on all platforms supported by the [`tikv-jemallocator`] crate.
+Supported on all platforms supported by the [`jemallocator`] crate.
 
 ## Example
 
@@ -18,10 +18,10 @@ Supported on all platforms supported by the [`tikv-jemallocator`] crate.
 
 use std::thread;
 use std::time::Duration;
-use tikv_jemalloc_ctl::{stats, epoch};
+use jemalloc_ctl::{stats, epoch};
 
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
     // Obtain a MIB for the `epoch`, `stats.allocated`, and
@@ -61,10 +61,10 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in `jemalloc-ctl` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[`tikv-jemallocator`]: https://github.com/tikv/jemallocator
+[`jemallocator`]: https://github.com/tikv/jemallocator
 [travis]: https://travis-ci.com/tikv/jemallocator
 [Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
-[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
-[crates.io]: https://crates.io/crates/tikv-jemallocator
-[docs]: https://docs.rs/tikv-jemallocator/badge.svg
-[docs.rs]: https://docs.rs/tikv-jemallocator/
+[Latest Version]: https://img.shields.io/crates/v/jemallocator.svg
+[crates.io]: https://crates.io/crates/jemallocator
+[docs]: https://docs.rs/jemallocator/badge.svg
+[docs.rs]: https://docs.rs/jemallocator/

--- a/jemalloc-ctl/src/arenas.rs
+++ b/jemalloc-ctl/src/arenas.rs
@@ -11,10 +11,10 @@ option! {
     /// ```
     /// #
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::arenas;
+    /// use jemalloc_ctl::arenas;
     /// println!("number of arenas: {}", arenas::narenas::read().unwrap());
     ///
     /// let arenas_mib = arenas::narenas::mib().unwrap();

--- a/jemalloc-ctl/src/config.rs
+++ b/jemalloc-ctl/src/config.rs
@@ -13,10 +13,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::config;
+    /// use jemalloc_ctl::config;
     /// let malloc_conf = config::malloc_conf::mib().unwrap();
     /// println!("default malloc conf: {}", malloc_conf.read().unwrap());
     /// # }

--- a/jemalloc-ctl/src/error.rs
+++ b/jemalloc-ctl/src/error.rs
@@ -19,7 +19,7 @@ impl NonZeroT for i64 {
 
 pub type NonZeroCInt = <c_int as NonZeroT>::T;
 
-/// Errors of the `tikv_jemalloc_sys::mallct`-family of functions.
+/// Errors of the `jemalloc_sys::mallct`-family of functions.
 ///
 /// The `jemalloc-sys` crate: `mallctl`, `mallctlnametomib`, and `mallctlbymib``
 /// functions return `0` on success; otherwise they return an error value.

--- a/jemalloc-ctl/src/keys.rs
+++ b/jemalloc-ctl/src/keys.rs
@@ -9,10 +9,10 @@
 //!
 //! ```
 //! #[global_allocator]
-//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 //!
 //! fn main() {
-//!     use tikv_jemalloc_ctl::{Access, AsName, Name, Mib};
+//!     use jemalloc_ctl::{Access, AsName, Name, Mib};
 //!     use libc::{c_uint, c_char};
 //!     let name = b"arenas.nbins\0".name();
 //!     let nbins: c_uint = name.read().unwrap();

--- a/jemalloc-ctl/src/lib.rs
+++ b/jemalloc-ctl/src/lib.rs
@@ -21,10 +21,10 @@
 //! ```no_run
 //! use std::thread;
 //! use std::time::Duration;
-//! use tikv_jemalloc_ctl::{stats, epoch};
+//! use jemalloc_ctl::{stats, epoch};
 //!
 //! #[global_allocator]
-//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 //!
 //! fn main() {
 //!     loop {
@@ -44,10 +44,10 @@
 //! ```no_run
 //! use std::thread;
 //! use std::time::Duration;
-//! use tikv_jemalloc_ctl::{stats, epoch};
+//! use jemalloc_ctl::{stats, epoch};
 //!
 //! #[global_allocator]
-//! static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+//! static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 //!
 //! fn main() {
 //!     let e = epoch::mib().unwrap();
@@ -72,7 +72,7 @@
 
 #[cfg(test)]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use crate::std::{fmt, mem, num, ops, ptr, result, slice, str};
 #[cfg(not(feature = "use_std"))]
@@ -107,10 +107,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::version;
+    /// use jemalloc_ctl::version;
     /// println!("jemalloc version {}", version::read().unwrap());
     /// let version_mib = version::mib().unwrap();
     /// println!("jemalloc version {}", version_mib.read().unwrap());
@@ -131,12 +131,12 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// # #[cfg(not(target_os = "macos"))] {
     /// #
-    /// use tikv_jemalloc_ctl::background_thread;
+    /// use jemalloc_ctl::background_thread;
     /// let bg = background_thread::mib().unwrap();
     /// let s = bg.read().unwrap();
     /// println!("background_threads enabled: {}", s);
@@ -161,12 +161,12 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// # #[cfg(not(target_os = "macos"))] {
     /// #
-    /// use tikv_jemalloc_ctl::max_background_threads;
+    /// use jemalloc_ctl::max_background_threads;
     /// let m = max_background_threads::mib().unwrap();
     /// println!("max_background_threads: {}", m.read().unwrap());
     /// m.write(0).unwrap();
@@ -193,11 +193,11 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
     /// #
-    /// use tikv_jemalloc_ctl::epoch;
+    /// use jemalloc_ctl::epoch;
     /// let e = epoch::mib().unwrap();
     /// let a = e.advance().unwrap();
     /// let b = e.advance().unwrap();

--- a/jemalloc-ctl/src/opt.rs
+++ b/jemalloc-ctl/src/opt.rs
@@ -15,10 +15,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let abort = opt::abort::mib().unwrap();
     /// println!("abort on warning: {}", abort.read().unwrap());
     /// # }
@@ -42,10 +42,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let dss = opt::dss::read().unwrap();
     /// println!("dss priority: {}", dss);
     /// # }
@@ -67,10 +67,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let narenas = opt::narenas::read().unwrap();
     /// println!("number of arenas: {}", narenas);
     /// # }
@@ -101,10 +101,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let junk = opt::junk::read().unwrap();
     /// println!("junk filling: {}", junk);
     /// # }
@@ -129,10 +129,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let zero = opt::zero::read().unwrap();
     /// println!("zeroing: {}", zero);
     /// # }
@@ -154,10 +154,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let tcache = opt::tcache::read().unwrap();
     /// println!("thread-local caching: {}", tcache);
     /// # }
@@ -179,10 +179,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let lg_tcache_max = opt::lg_tcache_max::read().unwrap();
     /// println!("max cached allocation size: {}", 1 << lg_tcache_max);
     /// # }
@@ -205,10 +205,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::opt;
+    /// use jemalloc_ctl::opt;
     /// let background_thread = opt::background_thread::read().unwrap();
     /// println!("background threads since initialization: {}", background_thread);
     /// # }

--- a/jemalloc-ctl/src/raw.rs
+++ b/jemalloc-ctl/src/raw.rs
@@ -20,10 +20,10 @@ use libc::c_char;
 ///
 /// ```
 /// #[global_allocator]
-/// static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+/// static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 ///
 /// fn main() {
-///     use tikv_jemalloc_ctl::raw;
+///     use jemalloc_ctl::raw;
 ///     use libc::{c_uint, c_char};
 ///     unsafe {
 ///         let mut mib = [0; 4];
@@ -42,7 +42,7 @@ pub fn name_to_mib(name: &[u8], mib: &mut [usize]) -> Result<()> {
         validate_name(name);
 
         let mut len = mib.len();
-        cvt(tikv_jemalloc_sys::mallctlnametomib(
+        cvt(jemalloc_sys::mallctlnametomib(
             name as *const _ as *const c_char,
             mib.as_mut_ptr(),
             &mut len,
@@ -66,7 +66,7 @@ pub fn name_to_mib(name: &[u8], mib: &mut [usize]) -> Result<()> {
 pub unsafe fn read_mib<T: Copy>(mib: &[usize]) -> Result<T> {
     let mut value = MaybeUninit { init: () };
     let mut len = mem::size_of::<T>();
-    cvt(tikv_jemalloc_sys::mallctlbymib(
+    cvt(jemalloc_sys::mallctlbymib(
         mib.as_ptr(),
         mib.len(),
         &mut value.init as *mut _ as *mut _,
@@ -92,7 +92,7 @@ pub unsafe fn read<T: Copy>(name: &[u8]) -> Result<T> {
 
     let mut value = MaybeUninit { init: () };
     let mut len = mem::size_of::<T>();
-    cvt(tikv_jemalloc_sys::mallctl(
+    cvt(jemalloc_sys::mallctl(
         name as *const _ as *const c_char,
         &mut value.init as *mut _ as *mut _,
         &mut len,
@@ -115,7 +115,7 @@ pub unsafe fn read<T: Copy>(name: &[u8]) -> Result<T> {
 /// sizes of `bool` and `u8` match, but `bool` cannot represent all values that
 /// `u8` can.
 pub unsafe fn write_mib<T>(mib: &[usize], mut value: T) -> Result<()> {
-    cvt(tikv_jemalloc_sys::mallctlbymib(
+    cvt(jemalloc_sys::mallctlbymib(
         mib.as_ptr(),
         mib.len(),
         ptr::null_mut(),
@@ -137,7 +137,7 @@ pub unsafe fn write_mib<T>(mib: &[usize], mut value: T) -> Result<()> {
 pub unsafe fn write<T>(name: &[u8], mut value: T) -> Result<()> {
     validate_name(name);
 
-    cvt(tikv_jemalloc_sys::mallctl(
+    cvt(jemalloc_sys::mallctl(
         name as *const _ as *const c_char,
         ptr::null_mut(),
         ptr::null_mut(),
@@ -160,7 +160,7 @@ pub unsafe fn write<T>(name: &[u8], mut value: T) -> Result<()> {
 /// `u8` can.
 pub unsafe fn update_mib<T>(mib: &[usize], mut value: T) -> Result<T> {
     let mut len = mem::size_of::<T>();
-    cvt(tikv_jemalloc_sys::mallctlbymib(
+    cvt(jemalloc_sys::mallctlbymib(
         mib.as_ptr(),
         mib.len(),
         &mut value as *mut _ as *mut _,
@@ -185,7 +185,7 @@ pub unsafe fn update<T>(name: &[u8], mut value: T) -> Result<T> {
     validate_name(name);
 
     let mut len = mem::size_of::<T>();
-    cvt(tikv_jemalloc_sys::mallctl(
+    cvt(jemalloc_sys::mallctl(
         name as *const _ as *const c_char,
         &mut value as *mut _ as *mut _,
         &mut len,

--- a/jemalloc-ctl/src/stats.rs
+++ b/jemalloc-ctl/src/stats.rs
@@ -19,10 +19,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let allocated = stats::allocated::mib().unwrap();
     ///
@@ -54,10 +54,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let active = stats::active::mib().unwrap();
     ///
@@ -86,10 +86,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let metadata = stats::metadata::mib().unwrap();
     ///
@@ -124,10 +124,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let resident = stats::resident::mib().unwrap();
     ///
@@ -159,10 +159,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let mapped = stats::mapped::mib().unwrap();
     ///
@@ -194,10 +194,10 @@ option! {
     ///
     /// ```rust
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::{epoch, stats};
+    /// use jemalloc_ctl::{epoch, stats};
     /// let e = epoch::mib().unwrap();
     /// let retained = stats::retained::mib().unwrap();
     ///

--- a/jemalloc-ctl/src/stats_print.rs
+++ b/jemalloc-ctl/src/stats_print.rs
@@ -123,7 +123,7 @@ where
         }
         opts[i] = 0;
 
-        tikv_jemalloc_sys::malloc_stats_print(
+        jemalloc_sys::malloc_stats_print(
             Some(callback::<W>),
             &mut state as *mut _ as *mut c_void,
             opts.as_ptr(),

--- a/jemalloc-ctl/src/thread.rs
+++ b/jemalloc-ctl/src/thread.rs
@@ -23,10 +23,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::thread;
+    /// use jemalloc_ctl::thread;
     /// let allocated = thread::allocatedp::mib().unwrap();
     /// let allocated = allocated.read().unwrap();
     ///
@@ -73,10 +73,10 @@ option! {
     ///
     /// ```
     /// # #[global_allocator]
-    /// # static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+    /// # static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     /// #
     /// # fn main() {
-    /// use tikv_jemalloc_ctl::thread;
+    /// use jemalloc_ctl::thread;
     /// let deallocated = thread::deallocatedp::mib().unwrap();
     /// let deallocated = deallocated.read().unwrap();
     ///

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tikv-jemalloc-sys"
+name = "jemalloc-sys"
 version = "0.4.3+5.2.1-patched.2"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/tikv/jemallocator"
 homepage = "https://github.com/tikv/jemallocator"
-documentation = "https://docs.rs/tikv-jemallocator-sys"
+documentation = "https://docs.rs/jemallocator-sys"
 keywords = ["allocator", "jemalloc"]
 description = """
 Rust FFI bindings to jemalloc

--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -3,7 +3,7 @@
 [![Travis-CI Status]][travis] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
 > Note: the Rust allocator API is implemented for `jemalloc` in the
-> [`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) crate.
+> [`jemallocator`](https://crates.io/crates/jemallocator) crate.
 
 ## Documentation
 
@@ -24,7 +24,7 @@
 ## Platform support
 
 See the platform support of the
-[`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) crate.
+[`jemallocator`](https://crates.io/crates/jemallocator) crate.
 
 ## Features
 
@@ -159,12 +159,12 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `tikv-jemalloc-sys` by you, as defined in the Apache-2.0 license,
+for inclusion in `jemalloc-sys` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
 [travis]: https://travis-ci.com/tikv/jemallocator
 [Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
-[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
-[crates.io]: https://crates.io/crates/tikv-jemallocator
-[docs]: https://docs.rs/tikv-jemallocator/badge.svg
-[docs.rs]: https://docs.rs/tikv-jemallocator/
+[Latest Version]: https://img.shields.io/crates/v/jemallocator.svg
+[crates.io]: https://crates.io/crates/jemallocator
+[docs]: https://docs.rs/jemallocator/badge.svg
+[docs.rs]: https://docs.rs/jemallocator/

--- a/jemalloc-sys/tests/malloc_conf_empty.rs
+++ b/jemalloc-sys/tests/malloc_conf_empty.rs
@@ -1,6 +1,6 @@
 #[test]
 fn malloc_conf_empty() {
     unsafe {
-        assert!(tikv_jemalloc_sys::malloc_conf.is_none());
+        assert!(jemalloc_sys::malloc_conf.is_none());
     }
 }

--- a/jemalloc-sys/tests/malloc_conf_set.rs
+++ b/jemalloc-sys/tests/malloc_conf_set.rs
@@ -16,11 +16,11 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 #[test]
 fn malloc_conf_set() {
     unsafe {
-        assert_eq!(tikv_jemalloc_sys::malloc_conf, malloc_conf);
+        assert_eq!(jemalloc_sys::malloc_conf, malloc_conf);
 
         let mut ptr: *const libc::c_char = std::ptr::null();
         let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
-        let r = tikv_jemalloc_sys::mallctl(
+        let r = jemalloc_sys::mallctl(
             &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
             &mut ptr as *mut *const _ as *mut libc::c_void,
             &mut ptr_len as *mut _,

--- a/jemalloc-sys/tests/unprefixed_malloc.rs
+++ b/jemalloc-sys/tests/unprefixed_malloc.rs
@@ -1,11 +1,11 @@
 #[cfg(prefixed)]
 #[test]
 fn malloc_is_prefixed() {
-    assert_ne!(tikv_jemalloc_sys::malloc as usize, libc::malloc as usize)
+    assert_ne!(jemalloc_sys::malloc as usize, libc::malloc as usize)
 }
 
 #[cfg(not(prefixed))]
 #[test]
 fn malloc_is_overridden() {
-    assert_eq!(tikv_jemalloc_sys::malloc as usize, libc::malloc as usize)
+    assert_eq!(jemalloc_sys::malloc as usize, libc::malloc as usize)
 }

--- a/jemallocator-global/Cargo.toml
+++ b/jemallocator-global/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tikv-jemallocator-global"
+name = "jemallocator-global"
 # Make sure to update the version in the readme as well:
 version = "0.4.0"
 authors = [
@@ -13,7 +13,7 @@ keywords = ["allocator", "jemalloc"]
 categories = ["memory-management", "api-bindings"]
 repository = "https://github.com/tikv/jemallocator"
 homepage = "https://github.com/tikv/jemallocator"
-documentation = "https://docs.rs/tikv-jemallocator-global"
+documentation = "https://docs.rs/jemallocator-global"
 description = """
 Sets `jemalloc` as the `#[global_allocator]`
 """
@@ -26,19 +26,19 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemallocator = { version = "0.4.0", path = "..", optional = true }
+jemallocator = { version = "0.4.0", path = "..", optional = true }
 cfg-if = "0.1"
 
 [features]
 default = []
 # Unconditionally sets jemalloc as the global allocator:
-force_global_jemalloc = [ "tikv-jemallocator" ]
+force_global_jemalloc = [ "jemallocator" ]
 
 # To enable `jemalloc` as the `#[global_allocator]` by default
 # for a particular target, white-list the target explicitly here:
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-tikv-jemallocator = { version = "0.4.0", path = "..", optional = false }
+jemallocator = { version = "0.4.0", path = "..", optional = false }
 
 # FIXME: https://github.com/gnzlbg/jemallocator/issues/91
 # [target.'cfg(target_os = "windows")'.dependencies]

--- a/jemallocator-global/README.md
+++ b/jemallocator-global/README.md
@@ -11,7 +11,7 @@ Add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-tikv-jemallocator-global = "0.4.0"
+jemallocator-global = "0.4.0"
 ```
 
 and `jemalloc` will be used as the `#[global_allocator]` on targets that support
@@ -22,7 +22,7 @@ it.
 * `force_global_jemalloc` (disabled by default): unconditionally sets `jemalloc`
   as the `#[global_allocator]`.
 
-[`tikv-jemallocator`]: https://github.com/tikv/jemallocator/
+[`jemallocator`]: https://github.com/tikv/jemallocator/
 
 ## Platform support 
 
@@ -46,12 +46,12 @@ at your option.
 ## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in `tikv-jemallocator-global` by you, as defined in the Apache-2.0 license,
+for inclusion in `jemallocator-global` by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
 [travis]: https://travis-ci.com/tikv/jemallocator
 [Travis-CI Status]: https://travis-ci.com/tikv/jemallocator.svg?branch=master
-[Latest Version]: https://img.shields.io/crates/v/tikv-jemallocator.svg
-[crates.io]: https://crates.io/crates/tikv-jemallocator
-[docs]: https://docs.rs/tikv-jemallocator/badge.svg
-[docs.rs]: https://docs.rs/tikv-jemallocator/
+[Latest Version]: https://img.shields.io/crates/v/jemallocator.svg
+[crates.io]: https://crates.io/crates/jemallocator
+[docs]: https://docs.rs/jemallocator/badge.svg
+[docs.rs]: https://docs.rs/jemallocator/

--- a/jemallocator-global/src/lib.rs
+++ b/jemallocator-global/src/lib.rs
@@ -28,7 +28,7 @@ cfg_if! {
     ))] {
         /// Sets `jemalloc` as the `#[global_allocator]`.
         #[global_allocator]
-        pub static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+        pub static JEMALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,5 +287,5 @@ pub unsafe fn usable_size<T>(ptr: *const T) -> usize {
 
 /// Raw bindings to jemalloc
 mod ffi {
-    pub use tikv_jemalloc_sys::*;
+    pub use jemalloc_sys::*;
 }

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys" }
+jemalloc-sys = { path = "../jemalloc-sys" }
 libc = "0.2"
 
 [build-dependencies]

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -8,6 +8,6 @@ use std::alloc::System;
 static A: System = System;
 
 use libc::{c_char, c_int, c_void};
-use tikv_jemalloc_sys::*;
+use jemalloc_sys::*;
 
 include!(concat!(env!("OUT_DIR"), "/all.rs"));

--- a/tests/background_thread_defaults.rs
+++ b/tests/background_thread_defaults.rs
@@ -1,13 +1,13 @@
 //! Test background threads run-time default settings.
 
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
 
 // Returns true if background threads are enabled.
 fn background_threads() -> bool {
-    tikv_jemalloc_ctl::opt::background_thread::read().unwrap()
+    jemalloc_ctl::opt::background_thread::read().unwrap()
 }
 
 #[test]

--- a/tests/background_thread_enabled.rs
+++ b/tests/background_thread_enabled.rs
@@ -4,7 +4,7 @@
 #![cfg(not(feature = "unprefixed_malloc_on_supported_platforms"))]
 #![cfg(not(target_env = "musl"))]
 
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
@@ -29,7 +29,7 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 fn background_threads_enabled() {
     // Background threads are unconditionally enabled at run-time by default.
     assert_eq!(
-        tikv_jemalloc_ctl::opt::background_thread::read().unwrap(),
+        jemalloc_ctl::opt::background_thread::read().unwrap(),
         true
     );
 }

--- a/tests/ffi.rs
+++ b/tests/ffi.rs
@@ -1,10 +1,10 @@
-extern crate tikv_jemalloc_sys as ffi;
+extern crate jemalloc_sys as ffi;
 
 use std::mem;
 use std::ptr;
 
 use libc::{c_char, c_void};
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/grow_in_place.rs
+++ b/tests/grow_in_place.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
 
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/malloctl.rs
+++ b/tests/malloctl.rs
@@ -1,6 +1,6 @@
 use std::alloc::{GlobalAlloc, Layout};
-use tikv_jemalloc_ctl::{Access, AsName};
-use tikv_jemallocator::Jemalloc;
+use jemalloc_ctl::{Access, AsName};
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/shrink_in_place.rs
+++ b/tests/shrink_in_place.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
 
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,5 +1,5 @@
 use std::alloc::{GlobalAlloc, Layout};
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;

--- a/tests/smoke_ffi.rs
+++ b/tests/smoke_ffi.rs
@@ -1,13 +1,13 @@
 // Work around https://github.com/gnzlbg/jemallocator/issues/19
 #[global_allocator]
-static A: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static A: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[test]
 fn smoke() {
     unsafe {
-        let ptr = tikv_jemalloc_sys::malloc(4);
+        let ptr = jemalloc_sys::malloc(4);
         *(ptr as *mut u32) = 0xDECADE;
         assert_eq!(*(ptr as *mut u32), 0xDECADE);
-        tikv_jemalloc_sys::free(ptr);
+        jemalloc_sys::free(ptr);
     }
 }

--- a/tests/usable_size.rs
+++ b/tests/usable_size.rs
@@ -1,4 +1,4 @@
-use tikv_jemallocator::Jemalloc;
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
@@ -6,5 +6,5 @@ static A: Jemalloc = Jemalloc;
 #[test]
 fn smoke() {
     let a = Box::new(3_u32);
-    assert!(unsafe { tikv_jemallocator::usable_size(&*a) } >= 4);
+    assert!(unsafe { jemallocator::usable_size(&*a) } >= 4);
 }


### PR DESCRIPTION
As discussed in https://github.com/gnzlbg/jemallocator/issues/173, I will also publish this crate in the name of `jemallocator`. Because tikv-jemallocator is already used by several projects, to make less disturbing to dependents, two crates will be published at the same time with only name differences.

The tikv-xxx versions are maintained in the branch tikv-main.