### PR TITLE
*: bump 0.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:    
+      - 'master'
+      - 'main'
+  push:
+    branches:
+      - 'master'
+      - 'main'
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0 - 2022-05-19
+
+- Update jemalloc to 5.3.0 (#23)
+
 # 0.4.3 - 2022-02-21
 
 - Added riscv64 support (#14)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci]][github actions] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
-This project is a simplified fork of [jemallocator](https://github.com/gnzlbg/jemallocator) focus on server.
+The project is published as `tikv-jemallocator` and `jemallocator` for historical reasons. The two crates are the same except names. It's OK to use either crate. But due to lack of permissions, only `jemallocator` and `jemalloc-sys` are updated. If you want to use other crates, `tikv-xxx` versions are still required.
 
 > Links against `jemalloc` and provides a `Jemalloc` unit type that implements
 > the allocator APIs and can be set as the `#[global_allocator]`
@@ -28,7 +28,7 @@ To use `tikv-jemallocator` add it as a dependency:
 [dependencies]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.4.3"
+tikv-jemallocator = "0.5"
 ```
 
 To set `tikv_jemallocator::Jemalloc` as the global allocator add this to your project:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![ci]][github actions] [![Latest Version]][crates.io] [![docs]][docs.rs]
 
+This project is the successor of [jemallocator](https://github.com/gnzlbg/jemallocator).
+
 The project is published as `tikv-jemallocator` and `jemallocator` for historical reasons. The two crates are the same except names. It's OK to use either crate. But due to lack of permissions, only `jemallocator` and `jemalloc-sys` are updated. If you want to use other crates, `tikv-xxx` versions are still required.
 
 > Links against `jemalloc` and provides a `Jemalloc` unit type that implements

--- a/jemalloc-ctl/Cargo.toml
+++ b/jemalloc-ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-jemalloc-ctl"
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     "Steven Fackler <sfackler@gmail.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
@@ -26,12 +26,12 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.4.0" }
+tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.5.0" }
 libc = { version = "0.2", default-features = false }
 paste = "1"
 
 [dev-dependencies]
-tikv-jemallocator = { path = "../jemallocator", version = "0.4.0" }
+tikv-jemallocator = { path = "../jemallocator", version = "0.5.0" }
 
 [features]
 default = []

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-jemalloc-sys"
-version = "0.4.3+5.3.0"
+version = "0.5.0+5.3.0"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -136,7 +136,7 @@ fn main() {
             .to_str()
             .unwrap()
             .replace("C:\\", "/c/")
-            .replace("\\", "/"),
+            .replace('\\', "/"),
     )
     .current_dir(&build_dir)
     .env("CC", compiler.path())

--- a/jemallocator-global/Cargo.toml
+++ b/jemallocator-global/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv-jemallocator-global"
 # Make sure to update the version in the readme as well:
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
     "The TiKV Project Developers",
@@ -26,7 +26,7 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemallocator = { version = "0.4.0", path = "../jemallocator", optional = true }
+tikv-jemallocator = { version = "0.5.0", path = "../jemallocator", optional = true }
 cfg-if = "0.1"
 
 [features]
@@ -38,7 +38,7 @@ force_global_jemalloc = [ "tikv-jemallocator" ]
 # for a particular target, white-list the target explicitly here:
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-tikv-jemallocator = { version = "0.4.0", path = "../jemallocator", optional = false }
+tikv-jemallocator = { version = "0.5.0", path = "../jemallocator", optional = false }
 
 # FIXME: https://github.com/gnzlbg/jemallocator/issues/91
 # [target.'cfg(target_os = "windows")'.dependencies]

--- a/jemallocator-global/README.md
+++ b/jemallocator-global/README.md
@@ -11,7 +11,7 @@ Add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-tikv-jemallocator-global = "0.4.0"
+tikv-jemallocator-global = "0.5.0"
 ```
 
 and `jemalloc` will be used as the `#[global_allocator]` on targets that support

--- a/jemallocator-global/src/lib.rs
+++ b/jemallocator-global/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! jemallocator-global = "0.4.0"
+//! jemallocator-global = "0.5.0"
 //! ```
 //!
 //! and `jemalloc` will be used as the `#[global_allocator]` on targets that

--- a/jemallocator/Cargo.toml
+++ b/jemallocator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv-jemallocator"
 # Make sure to update the version in the README as well:
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
@@ -33,12 +33,12 @@ test = false
 bench = false
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.4.0", default-features = false }
+tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.5.0", default-features = false }
 libc = { version = "^0.2.8", default-features = false }
 
 [dev-dependencies]
 paste = "1"
-tikv-jemalloc-ctl = { path = "../jemalloc-ctl", version = "0.4.0" }
+tikv-jemalloc-ctl = { path = "../jemalloc-ctl", version = "0.5.0" }
 
 [features]
 default = ["background_threads_runtime_support"]

--- a/jemallocator/tests/background_thread_enabled.rs
+++ b/jemallocator/tests/background_thread_enabled.rs
@@ -28,8 +28,5 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 #[test]
 fn background_threads_enabled() {
     // Background threads are unconditionally enabled at run-time by default.
-    assert_eq!(
-        tikv_jemalloc_ctl::opt::background_thread::read().unwrap(),
-        true
-    );
+    assert!(tikv_jemalloc_ctl::opt::background_thread::read().unwrap(),);
 }


### PR DESCRIPTION
Because we don't have enough permission to update all the crates releated to `jemallocator`, so we still need to stick to our own fork and publish to `jemallocator` and `jemalloc-sys` for historical reaons.

Everything related to `jemallocator` is maintained in master branch, and latest changes that work as `tikv-jemallocator` are maintained in main branch. And main branch will become the new default branch.