### PR TITLE
Correct a configuration example in the docs

### DIFF
--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -96,10 +96,10 @@ hyphens `-` are replaced with underscores `_`(see
   run-time options string that is processed prior to the `malloc_conf` global
   variable, the `/etc/malloc.conf` symlink, and the `MALLOC_CONF` environment
   variable (note: this variable might be prefixed as `_RJEM_MALLOC_CONF`). For
-  example, to change the default decay time to 30 seconds:
+  example, to change the default decay time for dirty pages to 30 seconds:
   
   ```
-  JEMALLOC_SYS_WITH_MALLOC_CONF=decay_ms:30000
+  JEMALLOC_SYS_WITH_MALLOC_CONF=dirty_decay_ms:30000
   ```
 
 * `JEMALLOC_SYS_WITH_LG_PAGE=<lg-page>`: Specify the base 2 log of the allocator


### PR DESCRIPTION
Fixes an example in the docs that seems to not work anymore with the current version. Its also possible to see that the new example is correct in the jemalloc docs [here](https://jemalloc.net/jemalloc.3.html#opt.dirty_decay_ms).