### PR TITLE
Add loongarch64 support

### DIFF
--- a/jemallocator/benches/roundtrip.rs
+++ b/jemallocator/benches/roundtrip.rs
@@ -31,6 +31,7 @@ const MIN_ALIGN: usize = 8;
     target_arch = "aarch64",
     target_arch = "powerpc64",
     target_arch = "powerpc64le",
+    target_arch = "loongarch64",
     target_arch = "mips64",
     target_arch = "riscv64",
     target_arch = "s390x",

--- a/jemallocator/src/lib.rs
+++ b/jemallocator/src/lib.rs
@@ -55,6 +55,7 @@ const ALIGNOF_MAX_ALIGN_T: usize = 8;
     target_arch = "aarch64",
     target_arch = "powerpc64",
     target_arch = "powerpc64le",
+    target_arch = "loongarch64",
     target_arch = "mips64",
     target_arch = "riscv64",
     target_arch = "s390x",


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html