### PR TITLE
Add `disable_cache_oblivious` feature

### DIFF
--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -40,6 +40,7 @@ background_threads = [ "background_threads_runtime_support" ]
 stats = []
 unprefixed_malloc_on_supported_platforms = []
 disable_initial_exec_tls = []
+disable_cache_oblivious = []
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--cfg",  "jemallocator_docs" ]

--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -84,6 +84,13 @@ This crate provides following cargo feature flags:
   the error `yourlib.so: cannot allocate memory in static TLS block`, you'll 
   likely want to enable this.
 
+* `disable_cache_oblivious` (disabled by default): when enabled, jemalloc is
+  built with the `--disable-cache-oblivious` option. In that case, all large
+  allocations are page-aligned as an implementation artifact. It may severely
+  harm CPU cache utilization. However, the cache-oblivious layout has a cost of
+  one extra page per large allocation which can be unfeasible for certain
+  applications.
+
 ### Environment variables
 
 `jemalloc` options taking values are passed via environment variables using the

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -262,6 +262,11 @@ fn main() {
         cmd.arg("--disable-initial-exec-tls");
     }
 
+    if env::var("CARGO_FEATURE_DISABLE_CACHE_OBLIVIOUS").is_ok() {
+        info!("CARGO_FEATURE_DISABLE_CACHE_OBLIVIOUS set");
+        cmd.arg("--disable-cache-oblivious");
+    }
+
     cmd.arg(format!("--host={}", gnu_target(&target)));
     cmd.arg(format!("--build={}", gnu_target(&host)));
     cmd.arg(format!("--prefix={}", out_dir.display()));


### PR DESCRIPTION
When this feature is used, it will build Jemalloc with `--disable-cache-oblivious`. The feature is disabled by default.