### PR TITLE
Fix definition of `c_bool` for non-MSVC targets.

### DIFF
--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -50,7 +50,14 @@
 #![deny(missing_docs, broken_intra_doc_links)]
 
 use libc::{c_char, c_int, c_uint, c_void, size_t};
+
+// jemalloc uses `stdbool.h` to define `bool` for which the Rust equivalent is `bool`.
+// However jemalloc also has its own `stdbool.h` that it uses when compiling with MSVC,
+// and this header defines `bool` as `BOOL` which in turn is `int`.
+#[cfg(target_env = "msvc")]
 type c_bool = c_int;
+#[cfg(not(target_env = "msvc"))]
+type c_bool = bool;
 
 /// Align the memory allocation to start at an address that is a
 /// multiple of `1 << la`.


### PR DESCRIPTION
Fixes #53