### PR TITLE
build: Fix build on riscv64gc-unknown-linux-musl

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -364,6 +364,7 @@ fn gnu_target(target: &str) -> String {
         "x86_64-pc-windows-gnu" => "x86_64-w64-mingw32".to_string(),
         "armv7-linux-androideabi" => "arm-linux-androideabi".to_string(),
         "riscv64gc-unknown-linux-gnu" => "riscv64-linux-gnu".to_string(),
+        "riscv64gc-unknown-linux-musl" => "riscv64-linux-musl".to_string(),
         s => s.to_string(),
     }
 }


### PR DESCRIPTION
The configure step for jemalloc fails to recognize the rustc target `riscv64gc-unknown-linux-musl`:
```
  --- stderr
  Invalid configuration `riscv64gc-unknown-linux-musl': machine `riscv64gc-unknown' not recognized
  configure: error: /bin/sh build-aux/config.sub riscv64gc-unknown-linux-musl failed
  thread 'main' panicked at /home/marv/.cargo/registry/src/index.crates.io-6f17d22bba15001f/jemalloc-sys-0.5.4+5.3.0-patched/build.rs:351:9:
  command did not execute successfully: cd "/mnt/data/devel/ripgrep/target/release/build/jemalloc-sys-eb3f9d51d93e319f/out/build" && CC="cc" CFLAGS="-O3 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -march=rv64gc -mabi=lp64d -mcmodel=medany -Wall -g -ggdb3 -O0" CPPFLAGS="-O3 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -march=rv64gc -mabi=lp64d -mcmodel=medany -Wall -g -ggdb3 -O0" LDFLAGS="-O3 -ffunction-sections -fdata-sections -fPIC -gdwarf-4 -fno-omit-frame-pointer -march=rv64gc -mabi=lp64d -mcmodel=medany -Wall -g -ggdb3 -O0" "sh" "/mnt/data/devel/ripgrep/target/release/build/jemalloc-sys-eb3f9d51d93e319f/out/build/configure" "--disable-cxx" "--enable-doc=no" "--enable-shared=no" "--with-jemalloc-prefix=_rjem_" "--with-private-namespace=_rjem_" "--host=riscv64gc-unknown-linux-musl" "--build=riscv64gc-unknown-linux-musl" "--prefix=/mnt/data/devel/ripgrep/target/release/build/jemalloc-sys-eb3f9d51d93e319f/out"
  expected success, got: exit status: 1
```

Add an entry to build.rs to translate between the GNU target and rustc target in order to work around the mismatch