### PR TITLE
Allow unprefixed jemalloc on musl targets

### DIFF
--- a/jemalloc-sys/src/env.rs
+++ b/jemalloc-sys/src/env.rs
@@ -19,7 +19,6 @@ pub static NO_BG_THREAD_TARGETS: &[&str] = &["musl"];
 //  (not jemalloc malloc), and then the standard library would free with jemalloc free,
 //  causing a segfault.”
 // https://github.com/rust-lang/rust/commit/e3b414d8612314e74e2b0ebde1ed5c6997d28e8d
-// https://github.com/rust-lang/rust/commit/536011d929ecbd1170baf34e09580e567c971f95
 // https://github.com/rust-lang/rust/commit/9f3de647326fbe50e0e283b9018ab7c41abccde3
 // https://github.com/rust-lang/rust/commit/ed015456a114ae907a36af80c06f81ea93182a24
-pub static NO_UNPREFIXED_MALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
+pub static NO_UNPREFIXED_MALLOC_TARGETS: &[&str] = &["android", "dragonfly", "darwin"];


### PR DESCRIPTION
Musl has supported replaced allocators since [1.1.20](https://musl.libc.org/releases.html), about a year after this exclusion was added. I have tested and I find no problems with jemalloc musl binaries. It seems reasonable to hand the responsibility for checking that their musl supports this back to the end user who is enabling the flag