### PR TITLE
Use --with-version when configuring jemalloc

### DIFF
--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.5.4+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -55,12 +55,16 @@ fn copy_recursively(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
+fn expect_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("{} was not set", name))
+}
+
 // TODO: split main functions and remove following allow.
 #[allow(clippy::cognitive_complexity)]
 fn main() {
-    let target = env::var("TARGET").expect("TARGET was not set");
-    let host = env::var("HOST").expect("HOST was not set");
-    let num_jobs = env::var("NUM_JOBS").expect("NUM_JOBS was not set");
+    let target = expect_env("TARGET");
+    let host = expect_env("HOST");
+    let num_jobs = expect_env("NUM_JOBS");
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR was not set"));
     let src_dir = env::current_dir().expect("failed to get current directory");
 

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -67,6 +67,11 @@ fn main() {
     let num_jobs = expect_env("NUM_JOBS");
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR was not set"));
     let src_dir = env::current_dir().expect("failed to get current directory");
+    let version = expect_env("CARGO_PKG_VERSION");
+    let je_version = version
+        .split_once('+')
+        .expect("jemalloc version is missing")
+        .1;
 
     info!("TARGET={}", target);
     info!("HOST={}", host);
@@ -151,7 +156,7 @@ fn main() {
     assert!(build_dir.exists());
 
     // Configuration files
-    let config_files = ["configure", "VERSION"];
+    let config_files = ["configure"];
 
     // Copy the configuration files to jemalloc's source directory
     for f in &config_files {
@@ -174,6 +179,7 @@ fn main() {
     .env("CFLAGS", cflags.clone())
     .env("LDFLAGS", cflags.clone())
     .env("CPPFLAGS", cflags)
+    .arg(format!("--with-version={je_version}"))
     .arg("--disable-cxx")
     .arg("--enable-doc=no")
     .arg("--enable-shared=no");

--- a/jemalloc-sys/configure/VERSION
+++ b/jemalloc-sys/configure/VERSION
@@ -1,1 +1,0 @@
-5.3.0-0-g54eaed1d8b56b1aa528be3bdd1877e59c56fa90c


### PR DESCRIPTION
This also changes the metadata of the version so that jemalloc still
reports the same version as before.

Fixes tikv/jemallocator#76