### PR TITLE
set `--disable-stats` if `stats` feature is not enabled

### DIFF
--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -32,7 +32,7 @@ libc = { version = "^0.2.8", default-features = false }
 cc = "^1.0.13"
 
 [features]
-default = ["background_threads_runtime_support"]
+default = ["stats", "background_threads_runtime_support"]
 profiling = []
 debug = []
 background_threads_runtime_support = []

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -265,6 +265,9 @@ fn main() {
     if env::var("CARGO_FEATURE_STATS").is_ok() {
         info!("CARGO_FEATURE_STATS set");
         cmd.arg("--enable-stats");
+    } else {
+        info!("CARGO_FEATURE_STATS not set");
+        cmd.arg("--disable-stats");
     }
 
     if env::var("CARGO_FEATURE_DISABLE_INITIAL_EXEC_TLS").is_ok() {

--- a/jemallocator/Cargo.toml
+++ b/jemallocator/Cargo.toml
@@ -41,7 +41,7 @@ paste = "1"
 tikv-jemalloc-ctl = { path = "../jemalloc-ctl", version = "0.5.0" }
 
 [features]
-default = ["background_threads_runtime_support"]
+default = ["stats", "background_threads_runtime_support"]
 alloc_trait = []
 profiling = ["tikv-jemalloc-sys/profiling"]
 debug = ["tikv-jemalloc-sys/debug"]


### PR DESCRIPTION
jemalloc defaults to enabling stats if `--enable-stats` is not present and `--disable-stats` was not set: https://github.com/jemalloc/jemalloc/blob/fa451de17fff73cc03c31ec8cd817d62927d1ff9/configure.ac#L1331-L1333

This issue was observed when we were building with `stats` and noticed the output of `malloc_stats_print` was basically the same.

Before:
<img width="394" alt="image" src="https://github.com/tikv/jemallocator/assets/112147643/ea6e4033-eb5f-4dab-ac4a-dcad3f8b1aa4">


After:
<img width="551" alt="image" src="https://github.com/tikv/jemallocator/assets/112147643/d91f640e-f1df-4f50-ab46-6d3dc47377c1">
