### PR TITLE
fix: compile aarch64-linux-android binary on linux when enable lto.

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -338,6 +338,11 @@ fn main() {
         println!("cargo:rustc-link-lib=atomic");
     }
     println!("cargo:rerun-if-changed=jemalloc");
+
+    cc::Build::new()
+        .file("src/pthread_atfork.c")
+        .compile("pthread_atfork");
+    println!("cargo:rerun-if-changed=src/pthread_atfork.c");
 }
 
 fn run_and_log(cmd: &mut Command, log_file: &Path) {

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -339,10 +339,15 @@ fn main() {
     }
     println!("cargo:rerun-if-changed=jemalloc");
 
-    cc::Build::new()
-        .file("src/pthread_atfork.c")
-        .compile("pthread_atfork");
-    println!("cargo:rerun-if-changed=src/pthread_atfork.c");
+    if target.contains("android") {
+        // These symbols are used by jemalloc on android but the really old android
+        // we're building on doesn't have them defined, so just make sure the symbols
+        // are available.
+        cc::Build::new()
+            .file("src/pthread_atfork.c")
+            .compile("pthread_atfork");
+        println!("cargo:rerun-if-changed=src/pthread_atfork.c");
+    }
 }
 
 fn run_and_log(cmd: &mut Command, log_file: &Path) {

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -890,20 +890,6 @@ pub type extent_merge_t = unsafe extern "C" fn(
     arena_ind: c_uint,
 ) -> c_bool;
 
-// These symbols are used by jemalloc on android but the really old android
-// we're building on doesn't have them defined, so just make sure the symbols
-// are available.
-#[no_mangle]
-#[cfg(target_os = "android")]
-#[doc(hidden)]
-pub extern "C" fn pthread_atfork(
-    _prefork: *mut u8,
-    _postfork_parent: *mut u8,
-    _postfork_child: *mut u8,
-) -> i32 {
-    0
-}
-
 #[allow(missing_docs)]
 mod env;
 

--- a/jemalloc-sys/src/pthread_atfork.c
+++ b/jemalloc-sys/src/pthread_atfork.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+
+// These symbols are used by jemalloc on android but the really old android
+// we're building on doesn't have them defined, so just make sure the symbols
+// are available.
+__attribute__((weak)) int
+pthread_atfork(uint8_t *prefork __attribute__((unused)),
+               uint8_t *postfork_parent __attribute__((unused)),
+               uint8_t *postfork_child __attribute__((unused))) {
+  return 0;
+}

--- a/jemalloc-sys/src/pthread_atfork.c
+++ b/jemalloc-sys/src/pthread_atfork.c
@@ -1,5 +1,3 @@
-#include <pthread.h>
-
 /*
  * These symbols are used by jemalloc on android but the really old android
  * we're building on doesn't have them defined, so just make sure the symbols

--- a/jemalloc-sys/src/pthread_atfork.c
+++ b/jemalloc-sys/src/pthread_atfork.c
@@ -1,11 +1,13 @@
-#include <stdint.h>
+#include <pthread.h>
 
-// These symbols are used by jemalloc on android but the really old android
-// we're building on doesn't have them defined, so just make sure the symbols
-// are available.
+/*
+ * These symbols are used by jemalloc on android but the really old android
+ * we're building on doesn't have them defined, so just make sure the symbols
+ * are available.
+ */
 __attribute__((weak)) int
-pthread_atfork(uint8_t *prefork __attribute__((unused)),
-               uint8_t *postfork_parent __attribute__((unused)),
-               uint8_t *postfork_child __attribute__((unused))) {
+pthread_atfork(void (*prepare)(void) __attribute__((unused)),
+               void (*parent)(void) __attribute__((unused)),
+               void (*child)(void) __attribute__((unused))) {
   return 0;
 }


### PR DESCRIPTION
This PR changes `pthread_atfork` from a strong symbol to a weak symbol.

## Related issue
#81 