### PR TITLE
Revise CI runner platform on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,11 @@ jobs:
             nobgt: 0
             no_tests: 1
             tag: arm64
-          - name: aarch64-apple-darwin
-            target: aarch64-apple-darwin
+          - name: x86_64-apple-darwin
+            target: x86_64-apple-darwin
             nobgt: 0
             no_tests: 1
-            tag: macos-14
+            tag: macos-13
           - name: x86_64-unknown-linux-gnu (nightly)
             target: x86_64-unknown-linux-gnu
             nobgt: 0
@@ -43,8 +43,8 @@ jobs:
             nobgt: 1
             no_tests: 1
             tag: ubuntu-latest
-          - name: x86_64-apple-darwin (stable)
-            target: x86_64-apple-darwin
+          - name: aarch64-apple-darwin (stable)
+            target: aarch64-apple-darwin
             nobgt: 0
             no_tests: 1
             tag: macos-latest

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -65,7 +65,7 @@ other targets are only tested on Rust nightly.
 | `powerpc64le-unknown-linux-gnu`     | ✓         | ✓       | ✗            |
 | `x86_64-unknown-linux-gnu` (tier 1) | ✓         | ✓       | ✓            |
 | **MacOSX targets:**                 | **build** | **run** | **jemalloc** |
-| `aarch64-apple-darwin` (tier 1)      | ✓         | ✓       | ✗            |
+| `aarch64-apple-darwin`              | ✓         | ✓       | ✗            |
 
 ## Features
 

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -65,7 +65,7 @@ other targets are only tested on Rust nightly.
 | `powerpc64le-unknown-linux-gnu`     | ✓         | ✓       | ✗            |
 | `x86_64-unknown-linux-gnu` (tier 1) | ✓         | ✓       | ✓            |
 | **MacOSX targets:**                 | **build** | **run** | **jemalloc** |
-| `x86_64-apple-darwin` (tier 1)      | ✓         | ✓       | ✗            |
+| `aarch64-apple-darwin` (tier 1)      | ✓         | ✓       | ✗            |
 
 ## Features
 


### PR DESCRIPTION
macos-latest has been switched from x86_64 to aarch64 (https://github.com/actions/runner-images/blob/main/README.md)

This PR is to revise macOS platform label and doc after the change.