### PR TITLE
allow per-target env detection

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -32,20 +32,12 @@ macro_rules! warning {
 fn env_inner_os(name: &str) -> Option<OsString> {
     let var = env::var_os(name);
     println!("cargo:rerun-if-env-changed={}", name);
-    match var {
-        Some(ref v) => println!("{} = {}", name, v.to_string_lossy()),
-        None => println!("{} unset", name),
-    }
     var
 }
 
 fn env_inner(name: &str) -> Result<String, env::VarError> {
     let var = env::var(name);
     println!("cargo:rerun-if-env-changed={}", name);
-    match &var {
-        Ok(v) => println!("{} = {}", name, v),
-        Err(_) => println!("{} unset", name),
-    }
     var
 }
 


### PR DESCRIPTION
This fixes #90.

It allows all environment variables that detected by `read_and_watch_env` and `read_and_watch_env_os` to be general or target-specific, which allows some unavoidable cross-compiling scene.

When compiling jemalloc-sys under Cargo projects, `TARGET` is set. Variables can be set as target-specific in the form of `<TARGET_TRIPLE>_MYENV`. For example, `AARCH64_APPLE_IOS_JEMALLOC_OVERRIDE` will set `JEMALLOC_OVERRIDE` when cargo is targeting aarch64-apple-ios, which is not affecting other targets.

When `AARCH64_APPLE_IOS_JEMALLOC_OVERRIDE` and `JEMALLOC_OVERRIDE` are both set, the build.rs will prefer prefixed one instead of the non-prefixed one. The unprefixed one would only be used when target-specific one is not set.