### PR TITLE
Add feature `disable_cache_oblivious` to jemallocator re-exports

### DIFF
--- a/jemallocator/Cargo.toml
+++ b/jemallocator/Cargo.toml
@@ -54,6 +54,7 @@ background_threads_runtime_support = ["tikv-jemalloc-sys/background_threads_runt
 background_threads = ["tikv-jemalloc-sys/background_threads"]
 unprefixed_malloc_on_supported_platforms = ["tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
 disable_initial_exec_tls = ["tikv-jemalloc-sys/disable_initial_exec_tls"]
+disable_cache_oblivious = ["tikv-jemalloc-sys/disable_cache_oblivious"]
 
 [package.metadata.docs.rs]
 features = []

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -69,8 +69,14 @@ other targets are only tested on Rust nightly.
 
 ## Features
 
-The `tikv-jemallocator` crate re-exports the [features of the `tikv-jemalloc-sys`
-dependency](https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md).
+This crate provides following cargo feature flags:
+
+* `alloc_trait` When the `alloc_trait` feature of this crate is enabled, it also implements the `Alloc` trait, allowing usage in collections.
+
+* `default` feature is `background_threads_runtime_support`.
+
+* The `tikv-jemallocator` crate re-exports the [features of the `tikv-jemalloc-sys`
+dependency](https://github.com/tikv/jemallocator/blob/master/jemalloc-sys/README.md#features).
 
 ## License
 


### PR DESCRIPTION
As described in https://github.com/tikv/jemallocator/issues/103, this feature could not be enabled.

I also updated the `README.md` to describe that there are more features than only the re-exported ones. Le me know if I should add anything else.