### PR TITLE
Fix compiler and clippy warnings

### DIFF
--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -26,6 +26,12 @@ is-it-maintained-issue-resolution = { repository = "tikv/jemallocator" }
 is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = [
+    'cfg(jemallocator_docs)',
+    'cfg(prefixed)',
+] }
+
 [dependencies]
 libc = { version = "^0.2.8", default-features = false }
 

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -387,9 +387,9 @@ extern "C" {
     /// The behavior is _undefined_ if:
     ///
     /// * `size` is not in range `[req_size, alloc_size]`, where `req_size` is
-    /// the size requested when performing the allocation, and `alloc_size` is
-    /// the allocation size returned by [`nallocx`], [`sallocx`], or
-    /// [`xallocx`],
+    ///   the size requested when performing the allocation, and `alloc_size` is
+    ///   the allocation size returned by [`nallocx`], [`sallocx`], or
+    ///   [`xallocx`],
     /// * `ptr` does not match a pointer earlier returned by the memory
     ///   allocation functions of this crate, or
     /// * `ptr` is null, or
@@ -453,8 +453,8 @@ extern "C" {
     /// Returns `0` on success, otherwise returns:
     ///
     /// * `EINVAL`: if `newp` is not null, and `newlen` is too large or too
-    /// small. Alternatively, `*oldlenp` is too large or too small; in this case
-    /// as much data as possible are read despite the error.
+    ///   small. Alternatively, `*oldlenp` is too large or too small; in this case
+    ///   as much data as possible are read despite the error.
     ///
     /// * `ENOENT`: `name` or mib specifies an unknown/invalid value.
     ///
@@ -463,7 +463,7 @@ extern "C" {
     /// * `EAGAIN`: A memory allocation failure occurred.
     ///
     /// * `EFAULT`: An interface with side effects failed in some way not
-    /// directly related to `mallctl` read/write processing.
+    ///   directly related to `mallctl` read/write processing.
     ///
     /// [jemalloc_mallctl]: http://jemalloc.net/jemalloc.3.html#mallctl_namespace
     #[cfg_attr(prefixed, link_name = "_rjem_mallctl")]

--- a/jemallocator/benches/roundtrip.rs
+++ b/jemallocator/benches/roundtrip.rs
@@ -18,19 +18,13 @@ use tikv_jemalloc_sys::MALLOCX_ALIGN;
 static A: Jemalloc = Jemalloc;
 
 // FIXME: replace with jemallocator::layout_to_flags
-#[cfg(all(any(
-    target_arch = "arm",
-    target_arch = "mips",
-    target_arch = "mipsel",
-    target_arch = "powerpc"
-)))]
+#[cfg(all(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc")))]
 const MIN_ALIGN: usize = 8;
 #[cfg(all(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "powerpc64le",
     target_arch = "loongarch64",
     target_arch = "mips64",
     target_arch = "riscv64",

--- a/jemallocator/src/lib.rs
+++ b/jemallocator/src/lib.rs
@@ -42,19 +42,13 @@ use libc::{c_int, c_void};
 // _Alignof(max_align_t), the malloc-APIs return memory whose alignment is
 // either the requested size if its a power-of-two, or the next smaller
 // power-of-two.
-#[cfg(any(
-    target_arch = "arm",
-    target_arch = "mips",
-    target_arch = "mipsel",
-    target_arch = "powerpc"
-))]
+#[cfg(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc"))]
 const ALIGNOF_MAX_ALIGN_T: usize = 8;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "powerpc64le",
     target_arch = "loongarch64",
     target_arch = "mips64",
     target_arch = "riscv64",


### PR DESCRIPTION
* Added hints for `jemallocator_docs` and `prefixed` configs.
* Removed superfluous checks on LE variants of `mips` and `powerpc64` arch [1].
* Fixed various indentations.

[1] target_arch `mipsel` and `powerpc64le` don't exist (anymore?). To check for the LE variants specifically, it would need the check on `target_endian` (https://doc.rust-lang.org/reference/conditional-compilation.html#target_endian) (cf. this comment: https://github.com/kata-containers/kata-containers/issues/10072#issuecomment-2251136045)

caveat: I have no hardware to test the change on the 2 affected architectures.