### PR TITLE
Update VERSION check in configure script to use BRE

### DIFF
--- a/jemalloc-sys/configure/configure
+++ b/jemalloc-sys/configure/configure
@@ -8256,7 +8256,7 @@ done
 # Check whether --with-version was given.
 if test "${with_version+set}" = set; then :
   withval=$with_version;
-    echo "${with_version}" | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+-[0-9]\+-g[0-9a-f]\+$' 2>&1 1>/dev/null
+    echo "${with_version}" | grep '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*-g[0-9a-f][0-9a-f]*$' 2>&1 1>/dev/null
     if test $? -eq 0 ; then
       echo "$with_version" > "${objroot}VERSION"
     else


### PR DESCRIPTION
POSIX BRE doesn't support `\+` so the grep fails on OpenBSD. Modify the version-check to use proper BRE

Fixes #112 