### PR TITLE
Remove build directory once build of `jemalloc-sys` finishes

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -318,6 +318,9 @@ fn main() {
         .arg("-j")
         .arg(num_jobs));
 
+    // Remove the build directory to avoid it wasting disk space in the target directory
+    fs::remove_dir_all(build_dir).unwrap();
+
     println!("cargo:root={}", out_dir.display());
 
     // Linkage directives to pull in jemalloc and its dependencies.
@@ -332,7 +335,7 @@ fn main() {
     } else {
         println!("cargo:rustc-link-lib=static=jemalloc_pic");
     }
-    println!("cargo:rustc-link-search=native={}/lib", build_dir.display());
+    println!("cargo:rustc-link-search=native={}/lib", out_dir.display());
     if target.contains("android") {
         println!("cargo:rustc-link-lib=gcc");
     } else if !target.contains("windows") {


### PR DESCRIPTION
And link to the libraries installed with `make install` instead. This saves disk space in the `target` directory. When you build jemalloc multiple times, with different Cargo profiles, RUSTFLAGS etc., the files on disk will begin accumulating for no reason (if there is a change, Cargo will just rebuild the library in a different directory).

Target directory disk space usage is a big concern to Rust users (https://blog.rust-lang.org/2025/02/13/2024-State-Of-Rust-Survey-results.html#challenges), and jemalloc is quite popular, so I think that it would be nice to improve this.

Fixes: https://github.com/tikv/jemallocator/issues/89