### PR TITLE
Respect jobserver set by Cargo

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -302,10 +302,14 @@ fn main() {
 
     // Make:
     let make = make_cmd(&host);
-    run(Command::new(make)
-        .current_dir(&build_dir)
-        .arg("-j")
-        .arg(num_jobs.clone()));
+    let mut cmd = Command::new(make);
+    cmd.current_dir(&build_dir);
+    if let Ok(makeflags) = std::env::var("CARGO_MAKEFLAGS") {
+        cmd.env("MAKEFLAGS", makeflags);
+    } else {
+        cmd.arg("-j").arg(num_jobs.clone());
+    }
+    run(&mut cmd);
 
     // Skip watching this environment variables to avoid rebuild in CI.
     if env::var("JEMALLOC_SYS_RUN_JEMALLOC_TESTS").is_ok() {

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -314,7 +314,7 @@ fn main() {
         run(cmd.arg("tests"));
 
         // Run tests:
-        run(make_command(make, &build_dir, &num_jobs).arg("check"));
+        run(Command::new(make).current_dir(&build_dir).arg("check"));
     }
 
     // Make install:


### PR DESCRIPTION
The `jemalloc-sys` crate currently does not respect the Make [jobserver](https://www.gnu.org/software/make/manual/html_node/Job-Slots.html) protocol, and hardcodes `-j$NUM_JOBS` Make jobs as set by Cargo.

Cargo recommends to use `CARGO_MAKEFLAGS` instead (https://doc.rust-lang.org/cargo/reference/environment-variables.html), to avoid oversubscribing CPU cores when building Jemalloc C++ code in parallel with other Rust crates.

Here is a small benchmark that I did on [hyperqueue](https://github.com/It4innovations/hyperqueue) with and without jobserver protocol support on AMD Zen 3 with 8 cores enabled:
```
/pr/it/hyperqueue [main/u]$ hyperfine --warmup 1 --runs 2 --prepare "rm -rf target" "cargo build --release" "JEMALLOC_JOBSERVER=1 cargo build --release" "cargo build" "JEMALLOC_JOBSERVER=1 cargo build"
Benchmark 1: cargo build --release
  Time (mean ± σ):     57.620 s ±  0.010 s    [User: 334.019 s, System: 37.222 s]
  Range (min … max):   57.613 s … 57.626 s    2 runs
 
Benchmark 2: JEMALLOC_JOBSERVER=1 cargo build --release
  Time (mean ± σ):     56.969 s ±  0.017 s    [User: 324.140 s, System: 36.739 s]
  Range (min … max):   56.956 s … 56.981 s    2 runs
 
Benchmark 3: cargo build
  Time (mean ± σ):     45.410 s ±  0.056 s    [User: 193.525 s, System: 37.347 s]
  Range (min … max):   45.371 s … 45.450 s    2 runs
 
Benchmark 4: JEMALLOC_JOBSERVER=1 cargo build
  Time (mean ± σ):     44.039 s ±  0.011 s    [User: 194.451 s, System: 37.357 s]
  Range (min … max):   44.031 s … 44.046 s    2 runs
 ```
With jobserver protocol support, the compilation finishes 2-3% faster.