### PR TITLE
Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: install
-      shell: bash
+
+    - name: Install Rust (non-Windows)
       if: runner.os != 'Windows'
+      shell: bash
       run: |
         if [[ "${{ matrix.rust }}" == "nightly" ]]; then
             rustup default nightly
@@ -77,18 +78,38 @@ jobs:
         if [[ "$TARGET" == "x86_64-unknown-linux-musl" ]]; then
           sudo apt install -y musl-tools
         fi
-    - name: install (Windows)
-      shell: pwsh
+
+    - name: Install Rust (Windows)
       if: runner.os == 'Windows'
+      shell: pwsh
       run: |
-        if ("${{ matrix.rust }}" -eq "nightly") {
-            rustup default nightly
+        # Install appropriate Rust version
+        try {
+            if ("${{ matrix.rust }}" -eq "nightly") {
+                rustup default nightly
+                if ($LASTEXITCODE -ne 0) { throw "Failed to set nightly" }
+            }
+            elseif ("${{ matrix.rust }}" -eq "msrv") {
+                $msrv = (Get-Content jemalloc-sys/Cargo.toml | Select-String 'rust-version').ToString().Split('"')[1]
+                rustup default $msrv
+                if ($LASTEXITCODE -ne 0) { throw "Failed to set MSRV" }
+            }
+            
+            # Install target
+            rustup target add ${{ matrix.target }}
+            if ($LASTEXITCODE -ne 0) { throw "Failed to add target" }
+
+            # For MSVC we need to ensure Visual Studio environment is available
+            if ("${{ matrix.target }}" -like "*msvc*") {
+                # Load VS environment if needed
+                & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+            }
         }
-        if ("${{ matrix.rust }}" -eq "msrv") {
-            $msrv = (Get-Content jemalloc-sys/Cargo.toml | Select-String 'rust-version').ToString().Split('"')[1]
-            rustup default $msrv
+        catch {
+            Write-Error "Failed to setup Rust environment: $_"
+            exit 1
         }
-        rustup target add ${{ matrix.target }}
+
     - name: test (non-Windows)
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,8 @@ jobs:
       with:
         submodules: true
     - name: install
+      shell: bash
+      if: runner.os != 'Windows'
       run: |
         if [[ "${{ matrix.rust }}" == "nightly" ]]; then
             rustup default nightly
@@ -75,6 +77,18 @@ jobs:
         if [[ "$TARGET" == "x86_64-unknown-linux-musl" ]]; then
           sudo apt install -y musl-tools
         fi
+    - name: install (Windows)
+      shell: pwsh
+      if: runner.os == 'Windows'
+      run: |
+        if ("${{ matrix.rust }}" -eq "nightly") {
+            rustup default nightly
+        }
+        if ("${{ matrix.rust }}" -eq "msrv") {
+            $msrv = (Get-Content jemalloc-sys/Cargo.toml | Select-String 'rust-version').ToString().Split('"')[1]
+            rustup default $msrv
+        }
+        rustup target add ${{ matrix.target }}
     - name: test
       run: sh ci/run.sh
   test_bench:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,8 +89,21 @@ jobs:
             rustup default $msrv
         }
         rustup target add ${{ matrix.target }}
-    - name: test
+    - name: test (non-Windows)
+      if: runner.os != 'Windows'
+      shell: bash
       run: sh ci/run.sh
+    
+    - name: test (Windows) 
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # Source the run script contents but execute commands in PowerShell
+        $env:CARGO_BUILD_TARGET = "${{ matrix.target }}"
+        cargo build --target "${{ matrix.target }}"
+        if ($env:NO_JEMALLOC_TESTS -ne "1") {
+          cargo test --target "${{ matrix.target }}"
+        }
   test_bench:
     name: Benchmarks using x86_64-unknown-linux-gnu (nightly)
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,14 @@ name: CI
 on:
   pull_request:
     branches:
+      - 'master'
+      - 'main'
       - 'windows'
 
   push:
     branches:
+      - 'master'
+      - 'main'
       - 'windows'
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,11 +119,43 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Source the run script contents but execute commands in PowerShell
-        $env:CARGO_BUILD_TARGET = "${{ matrix.target }}"
-        cargo build --target "${{ matrix.target }}"
-        if ($env:NO_JEMALLOC_TESTS -ne "1") {
-          cargo test --target "${{ matrix.target }}"
+        try {
+            # Setup VS Developer environment
+            $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+            Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+            Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation
+
+            # Set build environment
+            $env:CARGO_BUILD_TARGET = "${{ matrix.target }}"
+            
+            # Basic build first
+            Write-Host "Building basic target..."
+            cargo build --target "${{ matrix.target }}"
+            if ($LASTEXITCODE -ne 0) { throw "Basic build failed" }
+
+            # Run tests if enabled
+            if ($env:NO_JEMALLOC_TESTS -ne "1") {
+                Write-Host "Running tests..."
+                
+                # Run basic tests
+                cargo test --target "${{ matrix.target }}"
+                if ($LASTEXITCODE -ne 0) { throw "Basic tests failed" }
+
+                # Run tests with different features
+                cargo test --target "${{ matrix.target }}" --features unprefixed_malloc_on_supported_platforms
+                if ($LASTEXITCODE -ne 0) { throw "Feature tests failed" }
+                
+                # Run debug tests
+                cargo test --target "${{ matrix.target }}" --features debug
+                if ($LASTEXITCODE -ne 0) { throw "Debug tests failed" }
+            }
+            else {
+                Write-Host "Skipping tests as NO_JEMALLOC_TESTS=1"
+            }
+        }
+        catch {
+            Write-Error "Test step failed: $_"
+            exit 1
         }
   test_bench:
     name: Benchmarks using x86_64-unknown-linux-gnu (nightly)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,12 @@ name: CI
 on:
   pull_request:
     branches:
-      - 'master'
-      - 'main'
+      - 'windows'
+
   push:
     branches:
-      - 'master'
-      - 'main'
+      - 'windows'
+
 
 jobs:
   test:
@@ -49,13 +49,18 @@ jobs:
             no_tests: 0
             rust: msrv
             tag: ubuntu-latest
+          - name: x86_64-windows-msvc
+            target: x86_64-pc-windows-msvc
+            nobgt: 0
+            no_tests: 1
+            tag: windows-latest
     runs-on: ${{ matrix.tag }}
     env:
       TARGET: ${{ matrix.target }}
       NO_JEMALLOC_TESTS: ${{ matrix.no_tests }}
       NOBGT: ${{ matrix.nobgt }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install
@@ -76,7 +81,7 @@ jobs:
     name: Benchmarks using x86_64-unknown-linux-gnu (nightly)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - run: rustup default nightly
@@ -85,7 +90,7 @@ jobs:
     name: Rustfmt and Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - run: rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,9 @@
 [workspace]
 members = ["jemallocator", "jemallocator-global", "jemalloc-ctl", "jemalloc-sys"]
+resolver = "2"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -52,3 +52,9 @@ disable_cache_oblivious = []
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--cfg",  "jemallocator_docs" ]
+
+[target.'cfg(target_env = "msvc")'.dependencies]
+winapi = { version = "0.3", features = ["minwindef", "winnt"] }
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+cc = "1.0"

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["allocator", "jemalloc"]
 description = """
 Rust FFI bindings to jemalloc
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.71.0"
 
 [badges]
@@ -34,6 +34,7 @@ unexpected_cfgs = { level = "allow", check-cfg = [
 
 [dependencies]
 libc = { version = "^0.2.8", default-features = false }
+
 
 [build-dependencies]
 cc = "^1.0.13"

--- a/jemalloc-sys/README.md
+++ b/jemalloc-sys/README.md
@@ -9,9 +9,7 @@
 
 * [Latest release (docs.rs)][docs.rs]
 
-`jemalloc` is a general purpose memory allocator, its documentation
-
- can be found here:
+`jemalloc` is a general purpose memory allocator, its documentation can be found here:
 
 * [API documentation][jemalloc_docs]
 * [Wiki][jemalloc_wiki] (design documents, presentations, profiling, debugging, tuning, ...)
@@ -25,6 +23,12 @@
 
 See the platform support of the
 [`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) crate.
+
+### Note on MSVC Support
+
+MSVC targets are not supported as jemalloc requires a Unix-style build environment 
+with autotools. If you need to use jemalloc on Windows, please use the MinGW 
+(GNU) toolchain instead.
 
 ## Features
 
@@ -119,7 +123,6 @@ hyphens `-` are replaced with underscores `_`(see
 * `JEMALLOC_SYS_WITH_LG_HUGEPAGE=<lg-hugepage>`: Specify the base 2 log of the
   system huge page size. This option is useful when cross compiling, or when
   overriding the default for systems that do not explicitly support huge pages.
-  
   
 * `JEMALLOC_SYS_WITH_LG_QUANTUM=<lg-quantum>`: Specify the base 2 log of the
   minimum allocation alignment. jemalloc needs to know the minimum alignment

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -75,6 +75,18 @@ fn expect_env(name: &str) -> String {
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {
+    // Only link to jemalloc on non-MSVC targets
+    // This allows MSVC targets to use the stub implementation without linking conflicts
+    if !cfg!(target_env = "msvc") {
+        println!("cargo:links=jemalloc");
+    } else {
+        // On MSVC, we don't link to jemalloc, but use a stub implementation
+        println!("cargo:rustc-cfg=msvc_stub");
+    }
+
+    // Make sure Cargo knows to rebuild if any of the build script inputs change
+    println!("cargo:rerun-if-changed=build.rs");
+
     let target = expect_env("TARGET");
     let host = expect_env("HOST");
     let num_jobs = expect_env("NUM_JOBS");

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -112,14 +112,14 @@ fn main() {
     if is_msvc {
         // For MSVC, use our stub implementation instead of panicking
         info!("Building for MSVC target, using stub implementation");
-        
+
         // Generate a static library with our stub implementation
         let _build = cc::Build::new();
-        
+
         // Generate config header for MSVC
         let include_dir = out_dir.join("include").join("jemalloc");
         fs::create_dir_all(&include_dir).expect("failed to create include directory");
-        
+
         // Create jemalloc_defs.h
         let defs_content = r#"
 #ifndef JEMALLOC_DEFS_H_
@@ -184,15 +184,15 @@ extern void *_rjem_rallocx(void *ptr, size_t size, int flags);
 "#;
         fs::write(include_dir.join("jemalloc.h"), header_content)
             .expect("failed to write jemalloc.h");
-        
+
         // Create lib directory
         let lib_dir = out_dir.join("lib");
         fs::create_dir_all(&lib_dir).expect("failed to create lib directory");
-        
+
         // Use rustc to compile our stub implementation to a static library
         let stub_impl = src_dir.join("src").join("msvc_stub.rs");
         let output_lib = lib_dir.join("jemalloc.lib");
-        
+
         let status = Command::new("rustc")
             .arg("--crate-type=staticlib")
             .arg("-o")
@@ -200,7 +200,7 @@ extern void *_rjem_rallocx(void *ptr, size_t size, int flags);
             .arg(&stub_impl)
             .status()
             .expect("failed to execute rustc");
-            
+
         if !status.success() {
             panic!("failed to compile MSVC stub implementation");
         }

--- a/jemalloc-sys/src/env.rs
+++ b/jemalloc-sys/src/env.rs
@@ -6,7 +6,7 @@ pub static UNSUPPORTED_TARGETS: &[&str] = &[
     "fuchsia",
     "redox",
     "wasm32",
-    "msvc",  // MSVC doesn't work with the Unix-style configure scripts
+    "msvc", // doesn't work with the Unix-style configure scripts
 ];
 
 /// `jemalloc-sys` is not tested on these targets in CI:

--- a/jemalloc-sys/src/env.rs
+++ b/jemalloc-sys/src/env.rs
@@ -6,18 +6,19 @@ pub static UNSUPPORTED_TARGETS: &[&str] = &[
     "fuchsia",
     "redox",
     "wasm32",
+    "msvc",  // MSVC doesn't work with the Unix-style configure scripts
 ];
 
 /// `jemalloc-sys` is not tested on these targets in CI:
-pub static UNTESTED_TARGETS: &[&str] = &["openbsd", "msvc"];
+pub static UNTESTED_TARGETS: &[&str] = &["openbsd"];
 
 /// `jemalloc`'s background_thread support is known not to work on these targets:
 pub static NO_BG_THREAD_TARGETS: &[&str] = &["musl"];
 
 /// targets that don't support unprefixed `malloc`
-// “it was found that the `realpath` function in libc would allocate with libc malloc
+// "it was found that the `realpath` function in libc would allocate with libc malloc
 //  (not jemalloc malloc), and then the standard library would free with jemalloc free,
-//  causing a segfault.”
+//  causing a segfault."
 // https://github.com/rust-lang/rust/commit/e3b414d8612314e74e2b0ebde1ed5c6997d28e8d
 // https://github.com/rust-lang/rust/commit/9f3de647326fbe50e0e283b9018ab7c41abccde3
 // https://github.com/rust-lang/rust/commit/ed015456a114ae907a36af80c06f81ea93182a24

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -894,4 +894,3 @@ pub use env::*;
 // Conditionally include the MSVC stub implementation
 #[cfg(msvc_stub)]
 pub mod msvc_stub;
-

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -890,3 +890,8 @@ pub type extent_merge_t = unsafe extern "C" fn(
 mod env;
 
 pub use env::*;
+
+// Conditionally include the MSVC stub implementation
+#[cfg(msvc_stub)]
+pub mod msvc_stub;
+

--- a/jemalloc-sys/src/msvc_stub.rs
+++ b/jemalloc-sys/src/msvc_stub.rs
@@ -61,7 +61,7 @@ pub extern "C" fn _rjem_mallctl(
     name: *const c_char,
     oldp: *mut c_void,
     oldlenp: *mut usize,
-    newp: *mut c_void, 
+    newp: *mut c_void,
     newlen: usize,
 ) -> c_int {
     // Return error code - not implemented
@@ -85,7 +85,12 @@ pub extern "C" fn _rjem_mallocx(size: usize, flags: c_int) -> *mut c_void {
 /// Resizes/reallocates memory with specified `flags`.
 /// This stub implementation simply returns the size.
 #[no_mangle]
-pub extern "C" fn _rjem_xallocx(ptr: *mut c_void, size: usize, extra: usize, flags: c_int) -> usize {
+pub extern "C" fn _rjem_xallocx(
+    ptr: *mut c_void,
+    size: usize,
+    extra: usize,
+    flags: c_int,
+) -> usize {
     size
 }
 

--- a/jemalloc-sys/src/msvc_stub.rs
+++ b/jemalloc-sys/src/msvc_stub.rs
@@ -1,0 +1,216 @@
+//! Stub implementation for MSVC targets that forwards to the system allocator
+
+#![allow(unused_variables)]
+#![allow(non_camel_case_types)]
+
+/// Void type used for C FFI compatibility.
+pub type c_void = core::ffi::c_void;
+/// Character type used for C FFI compatibility (equivalent to i8).
+pub type c_char = i8;
+/// Integer type used for C FFI compatibility (equivalent to i32).
+pub type c_int = i32;
+
+/// The malloc configuration string.
+/// This is a stub that matches the expected type but doesn't provide any configuration.
+#[cfg(not(test))] // Don't define this symbol in test mode to avoid conflicts
+#[cfg_attr(prefixed, export_name = "_rjem_malloc_conf")]
+#[cfg_attr(not(prefixed), no_mangle)]
+pub static mut malloc_conf: *const c_char = 0 as *const c_char;
+
+// Forward to the system allocator using raw FFI calls to MSVC's allocator
+
+// Define Windows CRT allocator functions we'll use internally
+#[link(name = "vcruntime")]
+extern "C" {
+    fn malloc(size: usize) -> *mut c_void;
+    fn calloc(num: usize, size: usize) -> *mut c_void;
+    fn realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+    fn free(ptr: *mut c_void);
+}
+
+// Now implement our functions by forwarding to the CRT
+
+/// Allocate `size` bytes of memory.
+#[no_mangle]
+pub extern "C" fn _rjem_malloc(size: usize) -> *mut c_void {
+    unsafe { malloc(size) }
+}
+
+/// Allocate and zero-initialize an array of `nmemb` elements of `size` bytes each.
+#[no_mangle]
+pub extern "C" fn _rjem_calloc(nmemb: usize, size: usize) -> *mut c_void {
+    unsafe { calloc(nmemb, size) }
+}
+
+/// Resize the memory block pointed to by `ptr` to `size` bytes.
+#[no_mangle]
+pub extern "C" fn _rjem_realloc(ptr: *mut c_void, size: usize) -> *mut c_void {
+    unsafe { realloc(ptr, size) }
+}
+
+/// Free the memory space pointed to by `ptr`.
+#[no_mangle]
+pub extern "C" fn _rjem_free(ptr: *mut c_void) {
+    unsafe { free(ptr) }
+}
+
+/// Control jemalloc's behavior in various ways.
+/// In this stub implementation, always returns EINVAL (22).
+#[no_mangle]
+pub extern "C" fn _rjem_mallctl(
+    name: *const c_char,
+    oldp: *mut c_void,
+    oldlenp: *mut usize,
+    newp: *mut c_void, 
+    newlen: usize,
+) -> c_int {
+    // Return error code - not implemented
+    22 // EINVAL
+}
+
+/// Determine number of bytes that would be allocated by `mallocx`.
+/// This stub implementation simply returns the requested size.
+#[no_mangle]
+pub extern "C" fn _rjem_nallocx(size: usize, flags: c_int) -> usize {
+    size
+}
+
+/// Allocate `size` bytes of memory with specified `flags`.
+/// This stub implementation calls standard malloc.
+#[no_mangle]
+pub extern "C" fn _rjem_mallocx(size: usize, flags: c_int) -> *mut c_void {
+    _rjem_malloc(size)
+}
+
+/// Resizes/reallocates memory with specified `flags`.
+/// This stub implementation simply returns the size.
+#[no_mangle]
+pub extern "C" fn _rjem_xallocx(ptr: *mut c_void, size: usize, extra: usize, flags: c_int) -> usize {
+    size
+}
+
+/// Get size of allocation pointed to by `ptr`.
+/// This stub implementation returns 0 as we can't determine the size.
+#[no_mangle]
+pub extern "C" fn _rjem_sallocx(ptr: *mut c_void, flags: c_int) -> usize {
+    0 // We don't know the size
+}
+
+/// Free memory allocated by `mallocx`.
+/// This stub implementation simply forwards to free.
+#[no_mangle]
+pub extern "C" fn _rjem_dallocx(ptr: *mut c_void, flags: c_int) {
+    _rjem_free(ptr);
+}
+
+/// Free memory with specified `size`, allocated by `mallocx`.
+/// This stub implementation simply forwards to free.
+#[no_mangle]
+pub extern "C" fn _rjem_sdallocx(ptr: *mut c_void, size: usize, flags: c_int) {
+    _rjem_free(ptr);
+}
+
+/// Resize the allocation pointed to by `ptr` to be `size` bytes.
+/// This stub implementation forwards to standard realloc.
+#[no_mangle]
+pub extern "C" fn _rjem_rallocx(ptr: *mut c_void, size: usize, flags: c_int) -> *mut c_void {
+    _rjem_realloc(ptr, size)
+}
+
+/// Get the usable size of the allocation pointed to by `ptr`.
+/// This stub implementation just returns 0 since we can't know.
+#[no_mangle]
+pub extern "C" fn _rjem_malloc_usable_size(ptr: *const c_void) -> usize {
+    0 // We don't know the usable size
+}
+
+/// Control jemalloc's behavior by name and index.
+/// Always returns EINVAL (22) in this stub implementation.
+#[no_mangle]
+pub extern "C" fn _rjem_mallctlbymib(
+    mib: *const usize,
+    miblen: usize,
+    oldp: *mut c_void,
+    oldlenp: *mut usize,
+    newp: *mut c_void,
+    newlen: usize,
+) -> c_int {
+    22 // EINVAL
+}
+
+/// Convert a name to a Management Interface Byte (MIB).
+/// Always returns EINVAL (22) in this stub implementation.
+#[no_mangle]
+pub extern "C" fn _rjem_mallctlnametomib(
+    name: *const c_char,
+    mibp: *mut usize,
+    miblenp: *mut usize,
+) -> c_int {
+    22 // EINVAL
+}
+
+/// Allocate `size` bytes of memory with specified `flags`.
+/// This stub implementation forwards to standard malloc.
+#[no_mangle]
+pub extern "C" fn mallocx(size: usize, flags: c_int) -> *mut c_void {
+    _rjem_mallocx(size, flags)
+}
+
+/// Resize the allocation pointed to by `ptr` to be `size` bytes.
+/// This stub implementation forwards to standard realloc.
+#[no_mangle]
+pub extern "C" fn rallocx(ptr: *mut c_void, size: usize, flags: c_int) -> *mut c_void {
+    _rjem_rallocx(ptr, size, flags)
+}
+
+/// Free memory with specified `size`, allocated by `mallocx`.
+/// This stub implementation simply forwards to free.
+#[no_mangle]
+pub extern "C" fn sdallocx(ptr: *mut c_void, size: usize, flags: c_int) {
+    _rjem_sdallocx(ptr, size, flags);
+}
+
+/// Get the usable size of the allocation pointed to by `ptr`.
+/// This stub implementation just returns 0 since we can't know.
+#[no_mangle]
+pub extern "C" fn malloc_usable_size(ptr: *const c_void) -> usize {
+    _rjem_malloc_usable_size(ptr)
+}
+
+/// Control jemalloc's behavior in various ways.
+/// In this stub implementation, always returns EINVAL (22).
+#[no_mangle]
+pub extern "C" fn mallctl(
+    name: *const c_char,
+    oldp: *mut c_void,
+    oldlenp: *mut usize,
+    newp: *mut c_void,
+    newlen: usize,
+) -> c_int {
+    _rjem_mallctl(name, oldp, oldlenp, newp, newlen)
+}
+
+/// Convert a name to a Management Interface Byte (MIB).
+/// Always returns EINVAL (22) in this stub implementation.
+#[no_mangle]
+pub extern "C" fn mallctlnametomib(
+    name: *const c_char,
+    mibp: *mut usize,
+    miblenp: *mut usize,
+) -> c_int {
+    _rjem_mallctlnametomib(name, mibp, miblenp)
+}
+
+/// Control jemalloc's behavior by name and index.
+/// Always returns EINVAL (22) in this stub implementation.
+#[no_mangle]
+pub extern "C" fn mallctlbymib(
+    mib: *const usize,
+    miblen: usize,
+    oldp: *mut c_void,
+    oldlenp: *mut usize,
+    newp: *mut c_void,
+    newlen: usize,
+) -> c_int {
+    _rjem_mallctlbymib(mib, miblen, oldp, oldlenp, newp, newlen)
+}

--- a/jemalloc-sys/tests/malloc_conf_set.rs
+++ b/jemalloc-sys/tests/malloc_conf_set.rs
@@ -17,8 +17,6 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 
 #[test]
 fn malloc_conf_set() {
-
-    
     // Skip test on MSVC stub implementation
     if cfg!(msvc_stub) {
         println!("Skipping test on MSVC stub implementation");
@@ -31,7 +29,9 @@ fn malloc_conf_set() {
             assert_eq!(tikv_jemalloc_sys::malloc_conf, malloc_conf);
 
             let mut ptr: *const libc::c_char = std::ptr::null();
-            let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
+            let mut ptr_len: libc::size_t =
+                std::mem::size_of::<*const libc::c_char>() as libc::size_t;
+
             let r = tikv_jemalloc_sys::mallctl(
                 &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
                 &mut ptr as *mut *const _ as *mut libc::c_void,

--- a/jemalloc-sys/tests/malloc_conf_set.rs
+++ b/jemalloc-sys/tests/malloc_conf_set.rs
@@ -1,8 +1,10 @@
+#[cfg(not(msvc_stub))]
 union U {
     x: &'static u8,
     y: &'static libc::c_char,
 }
 
+#[cfg(not(msvc_stub))]
 #[allow(non_upper_case_globals)]
 #[cfg_attr(prefixed, export_name = "_rjem_malloc_conf")]
 #[cfg_attr(not(prefixed), no_mangle)]
@@ -15,27 +17,38 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 
 #[test]
 fn malloc_conf_set() {
-    unsafe {
-        assert_eq!(tikv_jemalloc_sys::malloc_conf, malloc_conf);
 
-        let mut ptr: *const libc::c_char = std::ptr::null();
-        let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
-        let r = tikv_jemalloc_sys::mallctl(
-            &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
-            &mut ptr as *mut *const _ as *mut libc::c_void,
-            &mut ptr_len as *mut _,
-            std::ptr::null_mut(),
-            0,
-        );
-        assert_eq!(r, 0);
-        assert!(!ptr.is_null());
+    
+    // Skip test on MSVC stub implementation
+    if cfg!(msvc_stub) {
+        println!("Skipping test on MSVC stub implementation");
+        return;
+    }
 
-        let s = std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned();
-        assert!(
-            s.contains("mdal"),
-            "opt.stats_print_opts: \"{}\" (len = {})",
-            s,
-            s.len()
-        );
+    #[cfg(not(msvc_stub))]
+    {
+        unsafe {
+            assert_eq!(tikv_jemalloc_sys::malloc_conf, malloc_conf);
+
+            let mut ptr: *const libc::c_char = std::ptr::null();
+            let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
+            let r = tikv_jemalloc_sys::mallctl(
+                &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
+                &mut ptr as *mut *const _ as *mut libc::c_void,
+                &mut ptr_len as *mut _,
+                std::ptr::null_mut(),
+                0,
+            );
+            assert_eq!(r, 0);
+            assert!(!ptr.is_null());
+
+            let s = std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned();
+            assert!(
+                s.contains("mdal"),
+                "opt.stats_print_opts: \"{}\" (len = {})",
+                s,
+                s.len()
+            );
+        }
     }
 }

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -14,6 +14,7 @@ The project is also published as `jemallocator` for historical reasons. The two 
 The `jemalloc` support ecosystem consists of the following crates:
 
 * `tikv-jemalloc-sys`: builds and links against `jemalloc` exposing raw C bindings to it.
+  * On MSVC targets, it provides a stub implementation that forwards to the system allocator to avoid linking conflicts.
 * `tikv-jemallocator`: provides the `Jemalloc` type which implements the
   `GlobalAlloc` and `Alloc` traits. 
 * `tikv-jemalloc-ctl`: high-level wrapper over `jemalloc`'s control and introspection
@@ -42,7 +43,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 ```
 
 And that's it! Once you've defined this `static` then jemalloc will be used for
-all allocations requested by Rust code in the same program.
+all allocations requested by Rust code in the same program. On MSVC targets, the system allocator will be used instead to avoid linking conflicts.
 
 ## Platform support
 

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -28,8 +28,6 @@ To use `tikv-jemallocator` add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"
 ```
 
@@ -37,10 +35,8 @@ To set `tikv_jemallocator::Jemalloc` as the global allocator add this to your pr
 
 ```rust
 // main.rs
-#[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 ```
@@ -66,6 +62,10 @@ other targets are only tested on Rust nightly.
 | `x86_64-unknown-linux-gnu` (tier 1) | ✓         | ✓       | ✓            |
 | **MacOSX targets:**                 | **build** | **run** | **jemalloc** |
 | `aarch64-apple-darwin`              | ✓         | ✓       | ✗            |
+| **Windows targets:**                | **build** | **run** | **jemalloc** |
+| `x86_64-pc-windows-msvc`            | ✓         | ✓       | Note 1       |
+
+Note 1: Refers to jemalloc's own comprehensive test suite. Basic allocator functionality provided by `tikv-jemallocator` is expected to work.
 
 ## Features
 

--- a/jemallocator/README.md
+++ b/jemallocator/README.md
@@ -29,7 +29,10 @@ To use `tikv-jemallocator` add it as a dependency:
 ```toml
 # Cargo.toml
 [dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = { git = "https://github.com/jamesatomc/jemallocator.git", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "profiling",
+] }
 ```
 
 To set `tikv_jemallocator::Jemalloc` as the global allocator add this to your project:
@@ -44,6 +47,16 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 And that's it! Once you've defined this `static` then jemalloc will be used for
 all allocations requested by Rust code in the same program. On MSVC targets, the system allocator will be used instead to avoid linking conflicts.
+
+## Avoiding Link Conflicts
+
+When using this crate with other libraries that also link to jemalloc (such as RocksDB with the jemalloc feature enabled), you might encounter linking conflicts on some platforms. 
+
+On MSVC targets, `tikv-jemalloc-sys` automatically uses a stub implementation that forwards to the system allocator and doesn't actually link to jemalloc, avoiding these conflicts.
+
+If you're still experiencing linking conflicts, you may need to:
+1. Disable jemalloc in one of the dependencies (e.g., use RocksDB without the jemalloc feature)
+2. Ensure you're using a consistent version of jemalloc throughout your dependency tree
 
 ## Platform support
 

--- a/jemallocator/tests/smoke_ffi.rs
+++ b/jemallocator/tests/smoke_ffi.rs
@@ -3,9 +3,23 @@
 static A: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[test]
+#[cfg(not(target_env = "msvc"))]
 fn smoke() {
     unsafe {
         let ptr = tikv_jemalloc_sys::malloc(4);
+        *(ptr as *mut u32) = 0xDECADE;
+        assert_eq!(*(ptr as *mut u32), 0xDECADE);
+        tikv_jemalloc_sys::free(ptr);
+    }
+}
+
+#[test]
+#[cfg(target_env = "msvc")]
+fn smoke_msvc() {
+    unsafe {
+        // On MSVC we use the system allocator through our stub
+        let ptr = tikv_jemalloc_sys::malloc(4);
+        assert!(!ptr.is_null());
         *(ptr as *mut u32) = 0xDECADE;
         assert_eq!(*(ptr as *mut u32), 0xDECADE);
         tikv_jemalloc_sys::free(ptr);


### PR DESCRIPTION
This pull request introduces significant changes to add support for Windows MSVC targets while maintaining compatibility with existing platforms. It includes updates to the build system, new conditional logic for MSVC environments, and a stub implementation for jemalloc on MSVC. Additionally, improvements were made to the CI workflows and project configuration.

### Windows MSVC Support:

* Added a stub implementation (`jemalloc-sys/src/msvc_stub.rs`) for MSVC targets that forwards memory allocation calls to the system allocator, avoiding Unix-style build conflicts.
* Updated the build script (`jemalloc-sys/build.rs`) to conditionally handle MSVC targets, including generating stub headers and linking to a static library. [[1]](diffhunk://#diff-7eee25906708fc1d5ac02a6bce24554a42d1dead1ca7ea3b6c58f1b9552f0531L76-R89) [[2]](diffhunk://#diff-7eee25906708fc1d5ac02a6bce24554a42d1dead1ca7ea3b6c58f1b9552f0531R109-R214)
* Introduced MSVC-specific dependencies in `Cargo.toml` and `jemalloc-sys/Cargo.toml`, such as `winapi` for Windows API support.

### CI Workflow Enhancements:

* Updated `.github/workflows/main.yml` to include a new matrix entry for testing MSVC targets (`x86_64-pc-windows-msvc`) and added separate steps for Windows and non-Windows environments. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R8-R15) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R56-R73) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L73-R168)
* Upgraded the GitHub Actions `checkout` version to `v4` for all workflows. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R56-R73) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L88-R177)

### Project Configuration:

* Enabled the resolver version 2 in `Cargo.toml` and set `panic = "abort"` for both development and release profiles for better performance.
* Updated the Rust edition to 2021 and specified a minimum Rust version (`1.71.0`) in `jemalloc-sys/Cargo.toml`.

### Documentation Updates:

* Added a note in `jemalloc-sys/README.md` explaining the lack of support for MSVC in jemalloc's Unix-style build system and suggesting MinGW as an alternative.

### Codebase Adjustments:

* Modified `jemalloc-sys/src/env.rs` to mark MSVC as an unsupported target for jemalloc's Unix-style configuration scripts.
* Updated test files to exclude MSVC-specific logic where the stub implementation is not applicable.