### PR TITLE
build: switch submodule to upstream jemalloc and link atomic for musl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jemalloc-sys/jemalloc"]
 	path = jemalloc-sys/jemalloc
-	url = https://github.com/tikv/jemalloc
+	url = https://github.com/jemalloc/jemalloc

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -344,7 +344,7 @@ fn main() {
     }
     // GCC may generate a __atomic_exchange_1 library call which requires -latomic
     // during the final linking. https://github.com/riscv-collab/riscv-gcc/issues/12
-    if target.contains("riscv") {
+    if target.contains("riscv") || target.contains("musl") {
         println!("cargo:rustc-link-lib=atomic");
     }
     println!("cargo:rerun-if-changed=jemalloc");


### PR DESCRIPTION
## Summary
Point the jemalloc submodule to the official jemalloc/jemalloc repo instead of the tikv/jemalloc fork.
Always link libatomic when building for *-unknown-linux-musl targets to prevent undefined-reference errors like __atomic_exchange_1.

## Details
.gitmodules: updated URL to https://github.com/jemalloc/jemalloc.
jemalloc-sys/build.rs: extend the existing RISC-V check so that libatomic is also linked for musl targets.

No behavioural changes in the resulting allocator.