### PR TITLE
`cat` the entire config.log

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -379,7 +379,7 @@ fn make_command(make_cmd: &str, build_dir: &Path, num_jobs: &str) -> Command {
 
 fn run_and_log(cmd: &mut Command, log_file: &Path) {
     execute(cmd, || {
-        run(Command::new("tail").arg("-n").arg("100").arg(log_file));
+        run(Command::new("cat").arg(log_file));
     })
 }
 


### PR DESCRIPTION
We recently hit a build error in the Rust compiler when trying to bump `cc` that came from `jemalloc-sys` while calling `configure`, but since the build script only shows the last 100 lines, we couldn't see the actual error in the build log: <https://github.com/rust-lang/rust/pull/146186#issuecomment-3257197839>

This change replaces `tail 100` with `cat` so that the entire `configure` log is printed in the build output.