### PR TITLE
Filter out `-flto` args from `cc`, don't set env vars that result in duplicated args

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -158,6 +158,7 @@ fn main() {
         .args()
         .iter()
         .map(|s| s.to_str().unwrap())
+        .filter(|s| !s.starts_with("-flto"))
         .collect::<Vec<_>>()
         .join(" ");
     info!("CC={:?}", compiler.path());
@@ -196,9 +197,7 @@ fn main() {
     )
     .current_dir(&build_dir)
     .env("CC", compiler.path())
-    .env("CFLAGS", cflags.clone())
-    .env("LDFLAGS", cflags.clone())
-    .env("CPPFLAGS", cflags)
+    .env("CFLAGS", cflags)
     .arg(format!("--with-version={je_version}"))
     .arg("--disable-cxx")
     .arg("--enable-doc=no")


### PR DESCRIPTION
[Attempting to update `cc` in the Rust compiler](https://github.com/rust-lang/rust/pull/146186) is causing [the build script in `tikv-jemalloc-sys` to fail to run `gold`](https://github.com/rust-lang/rust/actions/runs/17559152876/job/49870920308). `gold` failing (or running at all) is unexpected, but the root cause is that the compiler flags now include `-flto` where they didn't before.

Fix for this is to strip out any `-flto` args when `jemalloc` gets the compiler command from `cc` - since `jemalloc` isn't producing object files to be linked into the final Rust compilation, it doesn't need to use LTO.

Additionally, setting the `CPPFLAGS` and `LDFLAGS` are redundant to setting `CFLAGS` for the purposes of running `configure`: this results in the flags being triplicated in the C Compiler invocation.

Validated by [building the Rust compiler with this branch patched for `jemalloc`](https://github.com/rust-lang/rust/actions/runs/17960573848/job/51082785891).