### PR TITLE
Release `v0.6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.6.1 - 2025-10-15
+
+- Fix compiler and clippy warnings (#105)
+- Add feature `disable_cache_oblivious` to jemallocator re-exports (#104)
+- Document `JEMALLOC_OVERRIDE` (#107)
+- Harden `strerror_r` function detection (#117)
+- Respect jobserver set by Cargo (#120)
+- Make unprefixed consistently override the system allocator (#109)
+  - Adds new Cargo feature `override_allocator_on_supported_platforms`.
+- `cat` the entire `config.log` (#142)
+
 # 0.6.0 - 2024-07-14
 
 - Fix build on riscv64gc-unknown-linux-musl (#67) (#75)

--- a/jemalloc-ctl/Cargo.toml
+++ b/jemalloc-ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-jemalloc-ctl"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Steven Fackler <sfackler@gmail.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
@@ -26,12 +26,12 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.6.0" }
+tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.6.1" }
 libc = { version = "0.2", default-features = false }
 paste = "1"
 
 [dev-dependencies]
-tikv-jemallocator = { path = "../jemallocator", version = "0.6.0" }
+tikv-jemallocator = { path = "../jemallocator", version = "0.6.1" }
 
 [features]
 default = []

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",

--- a/jemallocator-global/Cargo.toml
+++ b/jemallocator-global/Cargo.toml
@@ -26,7 +26,7 @@ is-it-maintained-open-issues = { repository = "tikv/jemallocator" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-tikv-jemallocator = { version = "0.6.0", path = "../jemallocator", optional = true }
+tikv-jemallocator = { version = "0.6.1", path = "../jemallocator", optional = true }
 cfg-if = "0.1"
 
 [features]
@@ -38,7 +38,7 @@ force_global_jemalloc = [ "tikv-jemallocator" ]
 # for a particular target, white-list the target explicitly here:
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", path = "../jemallocator", optional = false }
+tikv-jemallocator = { version = "0.6.1", path = "../jemallocator", optional = false }
 
 # FIXME: https://github.com/gnzlbg/jemallocator/issues/91
 # [target.'cfg(target_os = "windows")'.dependencies]

--- a/jemallocator/Cargo.toml
+++ b/jemallocator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tikv-jemallocator"
 # Make sure to update the version in the README as well:
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Alex Crichton <alex@alexcrichton.com>",
     "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
@@ -37,12 +37,12 @@ name = "ffi"
 required-features = ["stats"]
 
 [dependencies]
-tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.6.0", default-features = false }
+tikv-jemalloc-sys = { path = "../jemalloc-sys", version = "0.6.1", default-features = false }
 libc = { version = "^0.2.8", default-features = false }
 
 [dev-dependencies]
 paste = "1"
-tikv-jemalloc-ctl = { path = "../jemalloc-ctl", version = "0.6.0" }
+tikv-jemalloc-ctl = { path = "../jemalloc-ctl", version = "0.6.1" }
 
 [features]
 default = ["background_threads_runtime_support"]


### PR DESCRIPTION
Motivation: To get https://github.com/tikv/jemallocator/pull/109 out. I decided to bump all crates for consistency, even though `jemallocator-global` doesn't have any changes.

I see that https://github.com/tikv/jemallocator/issues/143 exists, I agree that should be done, but I don't think it needs to be a blocker for getting the current things out?

r? @BusyJay.