### PR TITLE
add aarch64 runners back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-gnu
+            nobgt: 0
+            no_tests: 1
+            tag: ubuntu-24.04-arm
           - name: x86_64-apple-darwin
             target: x86_64-apple-darwin
             nobgt: 0


### PR DESCRIPTION
https://github.com/tikv/jemallocator/issues/114

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/