### PR TITLE
Define ALIGNOF_MAX_ALIGN_T for riscv32

### DIFF
--- a/jemallocator/src/lib.rs
+++ b/jemallocator/src/lib.rs
@@ -51,6 +51,7 @@ const ALIGNOF_MAX_ALIGN_T: usize = 8;
     target_arch = "powerpc64",
     target_arch = "loongarch64",
     target_arch = "mips64",
+    target_arch = "riscv32",
     target_arch = "riscv64",
     target_arch = "s390x",
     target_arch = "sparc64"


### PR DESCRIPTION
Max alignment per RISCV ABI is 16-bytes for both RV32 and RV64