### PR TITLE
Fix jemalloc builds for Windows MSVC targets

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -448,8 +448,8 @@ fn execute(cmd: &mut Command, on_fail: impl FnOnce()) {
 
 fn gnu_target(target: &str) -> String {
     match target {
-        "i686-pc-windows-msvc" => "i686-pc-win32".to_string(),
-        "x86_64-pc-windows-msvc" => "x86_64-pc-win32".to_string(),
+        "i686-pc-windows-msvc" => "i686-pc-mingw32".to_string(),
+        "x86_64-pc-windows-msvc" => "x86_64-pc-mingw32".to_string(),
         "i686-pc-windows-gnu" | "i686-pc-windows-gnullvm" => "i686-w64-mingw32".to_string(),
         "x86_64-pc-windows-gnu" | "x86_64-pc-windows-gnullvm" => "x86_64-w64-mingw32".to_string(),
         "aarch64-pc-windows-gnullvm" => "aarch64-w64-mingw32".to_string(),

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -352,8 +352,11 @@ fn main() {
         .arg("install_lib_static")
         .arg("install_include"));
 
-    // Try to remove the build directory to avoid it wasting disk space in the target directory
-    let _ = fs::remove_dir_all(build_dir);
+    // The MSVC build installs a differently named library, so keep its build
+    // directory and link the archive directly from there.
+    if !target.contains("windows") {
+        let _ = fs::remove_dir_all(&build_dir);
+    }
 
     println!("cargo:root={}", out_dir.display());
 
@@ -365,11 +368,12 @@ fn main() {
     // intrinsics that are libgcc specific (e.g. those intrinsics aren't present in
     // libcompiler-rt), so link that in to get that support.
     if target.contains("windows") {
-        println!("cargo:rustc-link-lib=static=jemalloc");
+        println!("cargo:rustc-link-lib=static=jemalloc_s");
+        println!("cargo:rustc-link-search=native={}/lib", build_dir.display());
     } else {
         println!("cargo:rustc-link-lib=static=jemalloc_pic");
+        println!("cargo:rustc-link-search=native={}/lib", out_dir.display());
     }
-    println!("cargo:rustc-link-search=native={}/lib", out_dir.display());
     if target.contains("android") {
         println!("cargo:rustc-link-lib=gcc");
     } else if !target.contains("windows") {


### PR DESCRIPTION
```markdown
## Summary

This PR fixes building `tikv-jemalloc-sys` for Windows MSVC targets.

## Changes

- Maps Windows MSVC targets to Autoconf-compatible target triples.
- Links the correct `jemalloc_s.lib` library on Windows.
- Preserves the build directory until the final Rust linking step.
- Adds the correct native library search path.

## Building on Windows

Requirements:

- Rust MSVC toolchain
- Visual Studio with the **Desktop development with C++** workload
- MSYS2 with `mingw32-make`

Open the Visual Studio x64 developer command prompt, then add the MSYS2
`ucrt64/bin` and `usr/bin` directories to `PATH`.

Verify the required tools:

```bat
where cl.exe
where lib.exe
where link.exe
where sh.exe
where mingw32-make.exe
```

Then build:

```bat
cargo build
```

For jemalloc profiling:

```toml
tikv-jemallocator = { version = "0.7.0", features = ["profiling"] }
```

Tested with the `x86_64-pc-windows-msvc` Rust target.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows builds by correctly preserving build output and linking the appropriate library.
  * Updated Windows target handling to improve compatibility with supported toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->