### PR TITLE
riscv: link libgcc for jemalloc's __ffsdi2

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -379,6 +379,13 @@ fn main() {
     // during the final linking. https://github.com/riscv-collab/riscv-gcc/issues/12
     if target.contains("riscv") {
         println!("cargo:rustc-link-lib=atomic");
+        // Base rv64gc has no count-trailing-zeros instruction (that is Zbb), so gcc
+        // lowers the ffs in bit_util.h to a __ffsdi2 call. compiler_builtins carries
+        // the rest of the *di2 family but not that one, so a -nodefaultlibs link
+        // needs libgcc named, as on android above.
+        if compiler.is_like_gnu() {
+            println!("cargo:rustc-link-lib=gcc");
+        }
     }
     println!("cargo:rerun-if-changed=jemalloc");
 


### PR DESCRIPTION
Base rv64gc has no count-trailing-zeros instruction, so gcc lowers the ffs in bit_util.h to a __ffsdi2 libgcc call. rust's compiler_builtins ships the rest of the *di2 family but not that one, so linking a static riscv64 binary fails with undefined reference to `__ffsdi2'.

Name libgcc for riscv as is already done for android, guarded on a gnu-like compiler so a clang/compiler-rt toolchain is left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builds for RISC-V targets using GNU-like compilers by ensuring the required compiler support library is linked.
  * Resolved linker failures on base RV64GC systems lacking the Zbb extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->