### PR TITLE
fix(jemalloc-sys): pin --libdir to avoid distro site-script lib64 redirect

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -327,6 +327,12 @@ fn main() {
     cmd.arg(format!("--host={}", gnu_target(&target)));
     cmd.arg(format!("--build={}", gnu_target(&host)));
     cmd.arg(format!("--prefix={}", out_dir.display()));
+    // Pin libdir explicitly so distro site-scripts (e.g. the OpenSUSE
+    // /usr/share/site/aarch64-unknown-linux-gnu script that rewrites libdir
+    // from `lib` to `lib64` on 64-bit hosts) cannot redirect the installed
+    // static libraries to a different subdirectory than the one we later pass
+    // to `cargo:rustc-link-search`.
+    cmd.arg(format!("--libdir={}/lib", out_dir.display()));
 
     run_and_log(&mut cmd, &build_dir.join("config.log"));
 


### PR DESCRIPTION
This was a :parrot: generated fix to a build error that has been buggin' the heck out of me in delta-io/delta-rs when using aarch64 machines.

Some Linux distributions ship an autoconf site-script (/usr/share/site/<triple>) that silently rewrites the configured libdir from `${prefix}/lib` to `${prefix}/lib64` for 64-bit hosts (e.g. the OpenSUSE aarch64 site script).  jemalloc is compiled via `./configure` inside the build script, so its static libraries end up in `$OUT_DIR/lib64`.  However, build.rs hard-codes the link-search path as `$OUT_DIR/lib`, so cargo can't find `libjemalloc_pic.a` and the build fails with:

  error: could not find native static library `jemalloc_pic`,
         perhaps an -L flag is missing?

Fix: pass `--libdir=${out_dir}/lib` explicitly to configure.  This overrides any site-script redirect and keeps the installed path consistent with the search path already emitted by build.rs.

Reproduces on: OpenSUSE Leap 16 aarch64 (site script at /usr/share/site/aarch64-unknown-linux-gnu).